### PR TITLE
make sure the step order is incremented

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1053,6 +1053,8 @@ func executePipeline(cmdCtx context.Context, options *core.PipelineOptions, dock
 			pr.Success = false
 			logger.WithField("Error", err).Error("Unable to store pipeline output")
 		}
+	} else {
+		stepCounter.Increment()
 	}
 
 	// We're sending our build finished but we're not done yet,

--- a/tests/projects/after-steps-fail/wercker.yml
+++ b/tests/projects/after-steps-fail/wercker.yml
@@ -1,0 +1,23 @@
+# ensure after-steps get run on failure
+#
+box:
+  id: alpine
+  cmd: /bin/sh
+
+build_fail:
+  steps:
+    - script:
+        code: false
+  after-steps:
+    - script:
+        code: echo "lala"
+
+
+build_true:
+  steps:
+    - script:
+        code: true
+  after-steps:
+    - script:
+        code: echo "lala true"
+


### PR DESCRIPTION
this hasn't changed in forever, we ran into this while trying to debug a
reporting error for after steps after a failed build, but this number
should be updated anyway