### PR TITLE
Allow users to mount local volumes

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -123,6 +123,7 @@ var (
 		cli.BoolTFlag{Name: "direct-mount", Usage: "Mount our binds read-write to the pipeline path."},
 		cli.StringSliceFlag{Name: "publish", Value: &cli.StringSlice{}, Usage: "Publish a port from the main container, same format as docker --publish."},
 		cli.BoolFlag{Name: "attach-on-error", Usage: "Attach shell to container if a step fails.", Hidden: true},
+		cli.BoolFlag{Name: "enable-volumes", Usage: "Mount local files and directories as volumes to your wercker container, specified in your wercker.yml."},
 		cli.BoolTFlag{Name: "enable-dev-steps", Hidden: true, Usage: `
 		Enable internal dev steps.
 		This enables:
@@ -135,6 +136,7 @@ var (
 		cli.BoolFlag{Name: "direct-mount", Usage: "Mount our binds read-write to the pipeline path."},
 		cli.StringSliceFlag{Name: "publish", Value: &cli.StringSlice{}, Usage: "Publish a port from the main container, same format as docker --publish."},
 		cli.BoolFlag{Name: "attach-on-error", Usage: "Attach shell to container if a step fails.", Hidden: true},
+		cli.BoolFlag{Name: "enable-volumes", Usage: "Mount local files and directories as volumes to your wercker container, specified in your wercker.yml."},
 		cli.BoolFlag{Name: "enable-dev-steps", Hidden: true, Usage: `
 		Enable internal dev steps.
 		This enables:

--- a/core/config.go
+++ b/core/config.go
@@ -21,9 +21,8 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/wercker/wercker/util"
+	"gopkg.in/yaml.v2"
 )
 
 // RawBoxConfig is the unwrapper for BoxConfig
@@ -43,6 +42,7 @@ type BoxConfig struct {
 	Registry   string
 	Entrypoint string
 	URL        string
+	Volumes    string
 }
 
 // IsExternal tells us if the box (service) is located on disk
@@ -323,7 +323,6 @@ func ReadWerckerYaml(searchDirs []string, allowDefault bool) ([]byte, error) {
 // ConfigFromYaml reads a []byte as yaml and turn it into a Config object
 func ConfigFromYaml(file []byte) (*Config, error) {
 	var m RawConfig
-
 	err := yaml.Unmarshal(file, &m)
 	// also need to ensure the RawConfig is valid before sending it back
 	if err == nil {

--- a/core/options.go
+++ b/core/options.go
@@ -359,6 +359,7 @@ type PipelineOptions struct {
 	DirectMount    bool
 	EnableDevSteps bool
 	PublishPorts   []string
+	EnableVolumes  bool
 	WerckerYml     string
 }
 
@@ -562,6 +563,7 @@ func NewPipelineOptions(c util.Settings, e *util.Environment) (*PipelineOptions,
 	directMount, _ := c.Bool("direct-mount")
 	enableDevSteps, _ := c.Bool("enable-dev-steps")
 	publishPorts, _ := c.StringSlice("publish")
+	enableVolumes, _ := c.Bool("enable-volumes")
 	werckerYml, _ := c.String("wercker-yml")
 
 	return &PipelineOptions{
@@ -612,6 +614,7 @@ func NewPipelineOptions(c util.Settings, e *util.Environment) (*PipelineOptions,
 		DirectMount:    directMount,
 		EnableDevSteps: enableDevSteps,
 		PublishPorts:   publishPorts,
+		EnableVolumes:  enableVolumes,
 		WerckerYml:     werckerYml,
 	}, nil
 }

--- a/docker/box.go
+++ b/docker/box.go
@@ -177,11 +177,11 @@ func (b *DockerBox) binds(env *util.Environment) ([]string, error) {
 			interpolatedVols = append(interpolatedVols, env.Interpolate(vol))
 		}
 		b.volumes = interpolatedVols
+		for _, volume := range b.volumes {
+			binds = append(binds, fmt.Sprintf("%s:%s:rw", volume, volume))
+		}
 	}
 
-	for _, volume := range b.volumes {
-		binds = append(binds, fmt.Sprintf("%s:%s:rw", volume, volume))
-	}
 	return binds, nil
 }
 

--- a/docker/box.go
+++ b/docker/box.go
@@ -50,6 +50,7 @@ type DockerBox struct {
 	logger          *util.LogEntry
 	entrypoint      string
 	image           *docker.Image
+	volumes         []string
 }
 
 // NewDockerBox from a name and other references
@@ -96,7 +97,6 @@ func NewDockerBox(boxConfig *core.BoxConfig, options *core.PipelineOptions, dock
 	if err != nil {
 		return nil, err
 	}
-
 	return &DockerBox{
 		Name:            name,
 		ShortName:       shortName,
@@ -110,6 +110,7 @@ func NewDockerBox(boxConfig *core.BoxConfig, options *core.PipelineOptions, dock
 		logger:          logger,
 		cmd:             cmd,
 		entrypoint:      entrypoint,
+		volumes:         []string{},
 	}, nil
 }
 
@@ -145,7 +146,7 @@ func (b *DockerBox) GetID() string {
 	return ""
 }
 
-func (b *DockerBox) binds() ([]string, error) {
+func (b *DockerBox) binds(env *util.Environment) ([]string, error) {
 	binds := []string{}
 	// Make our list of binds for the Docker attach
 	// NOTE(termie): we don't appear to need the "volumes" stuff, leaving
@@ -167,6 +168,19 @@ func (b *DockerBox) binds() ([]string, error) {
 			}
 			// volumes[b.options.MntPath(entry.Name())] = struct{}{}
 		}
+	}
+
+	if b.options.EnableVolumes {
+		vols := util.SplitSpaceOrComma(b.config.Volumes)
+		var interpolatedVols []string
+		for _, vol := range vols {
+			interpolatedVols = append(interpolatedVols, env.Interpolate(vol))
+		}
+		b.volumes = interpolatedVols
+	}
+
+	for _, volume := range b.volumes {
+		binds = append(binds, fmt.Sprintf("%s:%s:rw", volume, volume))
 	}
 	return binds, nil
 }
@@ -356,7 +370,8 @@ func (b *DockerBox) Run(ctx context.Context, env *util.Environment) (*docker.Con
 
 	b.logger.Debugln("Docker Container:", container.ID)
 
-	binds, err := b.binds()
+	binds, err := b.binds(env)
+
 	if err != nil {
 		return nil, err
 	}

--- a/test-all.sh
+++ b/test-all.sh
@@ -18,7 +18,7 @@ basicTest() {
   testName=$1
   shift
   printf "testing %s... " "$testName"
-  $wercker $@ --working-dir $workingDir > "${workingDir}/${testName}.log"
+  $wercker --debug $@ --working-dir $workingDir > "${workingDir}/${testName}.log"
   if [ $? -ne 0 ]; then
     printf "failed\n"
     cat "${workingDir}/${testName}.log"
@@ -84,10 +84,9 @@ testScratchPush () {
 
 runTests() {
   basicTest "source-path" build $testsDir/source-path || return 1
-  basicTest "test local services" build $testsDir/local-service/service-consumer || return 1
+  basicTest "test local services" build  $testsDir/local-service/service-consumer || return 1
   basicTest "test deploy" deploy $testsDir/deploy-no-targets || return 1
   basicTest "test deploy target" deploy --deploy-target test $testsDir/deploy-targets || return 1
-  basicTest "test shellstep" build --enable-dev-steps $testsDir/shellstep
   basicTest "test after steps" build --pipeline build_true $testsDir/after-steps-fail || return 1
 
   # this one will fail but we'll grep the log for After-step passed: test
@@ -100,6 +99,9 @@ runTests() {
 
   testDirectMount || return 1
   testScratchPush || return 1
+
+  # test runs locally but not in wercker build container
+  basicTest "test shellstep" build --enable-dev-steps $testsDir/shellstep || return 1
 }
 
 runTests

--- a/test-all.sh
+++ b/test-all.sh
@@ -84,7 +84,7 @@ testScratchPush () {
 
 runTests() {
   basicTest "source-path" build $testsDir/source-path || return 1
-  basicTest "test local services" build  $testsDir/local-service/service-consumer || return 1
+  basicTest "test local services" build $testsDir/local-service/service-consumer || return 1
   basicTest "test deploy" deploy $testsDir/deploy-no-targets || return 1
   basicTest "test deploy target" deploy --deploy-target test $testsDir/deploy-targets || return 1
   basicTest "test after steps" build --pipeline build_true $testsDir/after-steps-fail || return 1

--- a/util/environment.go
+++ b/util/environment.go
@@ -147,7 +147,7 @@ func (e *Environment) GetInclHidden(key string) string {
 		}
 	}
 
-	if e.Hidden.Map != nil {
+	if e.Hidden != nil && e.Hidden.Map != nil {
 		if val, ok := e.Hidden.Map[key]; ok {
 			return val
 		}

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,6 @@
-box: tcnksm/gox:1.5.1
+box:
+  id: tcnksm/gox:1.5.1
+  volumes: $CODE_PATH /var/run/docker.sock
 dev:
   box:
     id: busybox
@@ -138,3 +140,52 @@ deploy:
         bucket-url: $DOWNLOADS_BUCKET_URL/versions/$WERCKER_VERSION/
         key-id: $AWS_ACCESS_KEY_ID
         key-secret: $AWS_SECRET_ACCESS_KEY
+
+test:
+    steps:
+        - install-packages:
+            packages: openssh-client pkg-config libsystemd-journal-dev
+
+        - add-to-known_hosts:
+            hostname: github.com
+            fingerprint: "16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48"
+
+        - setup-go-workspace:
+            package-dir: github.com/wercker/wercker
+
+        - script:
+            name: glide install
+            code: |
+              export GO15VENDOREXPERIMENT=1
+              export GLIDE_VERSION=0.8.3
+              curl -LO https://github.com/Masterminds/glide/releases/download/${GLIDE_VERSION}/glide-${GLIDE_VERSION}-linux-amd64.tar.gz
+              tar -xvzf glide-${GLIDE_VERSION}-linux-amd64.tar.gz
+              cp linux-amd64/glide ./
+              ./glide install --quick
+
+        - script:
+            name: clear out the build binaries
+            code: |
+                rm -rf $GOPATH/pkg
+
+        - script:
+            name: gox
+            code: |
+                gox \
+                -ldflags="-X github.com/wercker/wercker/util.GitCommit=$WERCKER_GIT_COMMIT -X github.com/wercker/wercker/util.PatchVersion=$(( ($(date +%s) - $(date --date=20150101 +%s) )/(60*60*24) )) -X github.com/wercker/wercker/util.Compiled=$(date +%s)" \
+                  -os="linux" \
+                  -arch="amd64"\
+                  -output "$WERCKER_OUTPUT_DIR/latest/{{.OS}}_{{.Arch}}/wercker"
+        - script:
+            code: |
+                cp $WERCKER_OUTPUT_DIR/latest/linux_amd64/wercker $CODE_PATH
+                cd $CODE_PATH
+                $WERCKER_OUTPUT_DIR/latest/linux_amd64/./wercker b --build-id $WERCKER_BUILD_ID-1 --pipeline run-tests --enable-volumes
+
+run-tests:
+    steps:
+        - script:
+            code: |
+                unset WERCKER_BUILD_ID
+                cd $CODE_PATH 
+                ./test-all.sh

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,6 +1,5 @@
 box:
   id: tcnksm/gox:1.5.1
-  volumes: $CODE_PATH /var/run/docker.sock
 dev:
   box:
     id: busybox
@@ -142,6 +141,9 @@ deploy:
         key-secret: $AWS_SECRET_ACCESS_KEY
 
 test:
+    box:
+      id: tcnksm/gox:1.5.1
+      volumes: $CODE_PATH /var/run/docker.sock
     steps:
         - install-packages:
             packages: openssh-client pkg-config libsystemd-journal-dev


### PR DESCRIPTION
allows users to mount local volumes through a `Volumes` section in their wercker.yml file

in order to run this, users must use a `--enable-volumes` flag

we leverage this feature to test wercker inside of a wercker build container as well