### PR TITLE
Preliminary windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 vendor
-wercker
+wercker*
 .wercker
 .DS_STORE

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -1,0 +1,73 @@
+//   Copyright 2016 Wercker Holding BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+// +build !windows
+
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/codegangsta/cli"
+	"github.com/wercker/journalhook"
+	"github.com/wercker/wercker/util"
+	"golang.org/x/sys/unix"
+)
+
+func GetApp() *cli.App {
+	// logger.SetLevel(logger.DebugLevel)
+	// util.RootLogger().SetLevel("debug")
+	// util.RootLogger().Formatter = &logger.JSONFormatter{}
+
+	app := cli.NewApp()
+	setupUsageFormatter(app)
+	app.Author = "Team wercker"
+	app.Name = "wercker"
+	app.Usage = "build and deploy from the command line"
+	app.Email = "pleasemailus@wercker.com"
+	app.Version = util.FullVersion()
+	app.Flags = FlagsFor(GlobalFlagSet)
+	app.Commands = []cli.Command{
+		buildCommand,
+		devCommand,
+		checkConfigCommand,
+		deployCommand,
+		detectCommand,
+		// inspectCommand,
+		loginCommand,
+		logoutCommand,
+		pullCommand,
+		versionCommand,
+		documentCommand(app),
+	}
+	app.Before = func(ctx *cli.Context) error {
+		if ctx.GlobalBool("debug") {
+			util.RootLogger().Formatter = &util.VerboseFormatter{}
+			util.RootLogger().SetLevel("debug")
+		} else {
+			util.RootLogger().Formatter = &util.TerseFormatter{}
+			util.RootLogger().SetLevel("info")
+		}
+		if ctx.GlobalBool("journal") {
+			util.RootLogger().Hooks.Add(&journalhook.JournalHook{})
+			util.RootLogger().Out = ioutil.Discard
+		}
+		// Register the global signal handler
+		util.GlobalSigint().Register(os.Interrupt)
+		util.GlobalSigterm().Register(unix.SIGTERM)
+		return nil
+	}
+	return app
+}

--- a/cmd/app_windows.go
+++ b/cmd/app_windows.go
@@ -1,0 +1,64 @@
+//   Copyright 2016 Wercker Holding BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package cmd;
+
+import (
+	"os"
+
+	"github.com/codegangsta/cli"
+	"github.com/wercker/wercker/util"
+)
+
+func GetApp() *cli.App {
+	// logger.SetLevel(logger.DebugLevel)
+	// util.RootLogger().SetLevel("debug")
+	// util.RootLogger().Formatter = &logger.JSONFormatter{}
+
+	app := cli.NewApp()
+	setupUsageFormatter(app)
+	app.Author = "Team wercker"
+	app.Name = "wercker"
+	app.Usage = "build and deploy from the command line"
+	app.Email = "pleasemailus@wercker.com"
+	app.Version = util.FullVersion()
+	app.Flags = FlagsFor(GlobalFlagSet)
+	app.Commands = []cli.Command{
+		buildCommand,
+		devCommand,
+		checkConfigCommand,
+		deployCommand,
+		detectCommand,
+		// inspectCommand,
+		loginCommand,
+		logoutCommand,
+		pullCommand,
+		versionCommand,
+		documentCommand(app),
+	}
+	app.Before = func(ctx *cli.Context) error {
+		if ctx.GlobalBool("debug") {
+			util.RootLogger().Formatter = &util.VerboseFormatter{}
+			util.RootLogger().SetLevel("debug")
+		} else {
+			util.RootLogger().Formatter = &util.TerseFormatter{}
+			util.RootLogger().SetLevel("info")
+		}
+		// Register the global signal handler
+		util.GlobalSigint().Register(os.Interrupt)
+		return nil
+	}
+	return app
+}
+

--- a/cmd/devflags.go
+++ b/cmd/devflags.go
@@ -1,0 +1,31 @@
+//   Copyright 2016 Wercker Holding BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+// +build !windows
+
+package cmd
+
+import (
+	"github.com/codegangsta/cli"
+)
+
+// These flags affect our local execution environment
+var DevFlags = []cli.Flag{
+	cli.StringFlag{Name: "environment", Value: "ENVIRONMENT", Usage: "Specify additional environment variables in a file."},
+	cli.BoolFlag{Name: "verbose", Usage: "Print more information."},
+	cli.BoolFlag{Name: "no-colors", Usage: "Wercker output will not use colors (does not apply to step output)."},
+	cli.BoolFlag{Name: "debug", Usage: "Print additional debug information."},
+	cli.BoolFlag{Name: "journal", Usage: "Send logs to systemd-journald. Suppresses stdout logging."},
+}
+

--- a/cmd/devflags_windows.go
+++ b/cmd/devflags_windows.go
@@ -1,0 +1,27 @@
+//   Copyright 2016 Wercker Holding BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package cmd
+
+import (
+	"github.com/codegangsta/cli"
+)
+
+// These flags affect our local execution environment
+var DevFlags = []cli.Flag{
+	cli.StringFlag{Name: "environment", Value: "ENVIRONMENT", Usage: "Specify additional environment variables in a file."},
+	cli.BoolFlag{Name: "verbose", Usage: "Print more information."},
+	cli.BoolFlag{Name: "no-colors", Usage: "Wercker output will not use colors (does not apply to step output)."},
+	cli.BoolFlag{Name: "debug", Usage: "Print additional debug information."},
+}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -102,15 +102,6 @@ var (
 			the region named by --aws-region`},
 	}
 
-	// These flags affect our local execution environment
-	DevFlags = []cli.Flag{
-		cli.StringFlag{Name: "environment", Value: "ENVIRONMENT", Usage: "Specify additional environment variables in a file."},
-		cli.BoolFlag{Name: "verbose", Usage: "Print more information."},
-		cli.BoolFlag{Name: "no-colors", Usage: "Wercker output will not use colors (does not apply to step output)."},
-		cli.BoolFlag{Name: "debug", Usage: "Print additional debug information."},
-		cli.BoolFlag{Name: "journal", Usage: "Send logs to systemd-journald. Suppresses stdout logging."},
-	}
-
 	// These flags are advanced dev settings
 	InternalDevFlags = []cli.Flag{
 		cli.BoolTFlag{Name: "direct-mount", Usage: "Mount our binds read-write to the pipeline path."},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,13 +34,11 @@ import (
 	"github.com/fsouza/go-dockerclient"
 	"github.com/joho/godotenv"
 	"github.com/mreiferson/go-snappystream"
-	"github.com/wercker/journalhook"
 	"github.com/wercker/wercker/api"
 	"github.com/wercker/wercker/core"
 	"github.com/wercker/wercker/docker"
 	"github.com/wercker/wercker/util"
 	"golang.org/x/net/context"
-	"golang.org/x/sys/unix"
 )
 
 var (
@@ -328,52 +326,6 @@ var (
 		}
 	}
 )
-
-func GetApp() *cli.App {
-	// logger.SetLevel(logger.DebugLevel)
-	// util.RootLogger().SetLevel("debug")
-	// util.RootLogger().Formatter = &logger.JSONFormatter{}
-
-	app := cli.NewApp()
-	setupUsageFormatter(app)
-	app.Author = "Team wercker"
-	app.Name = "wercker"
-	app.Usage = "build and deploy from the command line"
-	app.Email = "pleasemailus@wercker.com"
-	app.Version = util.FullVersion()
-	app.Flags = FlagsFor(GlobalFlagSet)
-	app.Commands = []cli.Command{
-		buildCommand,
-		devCommand,
-		checkConfigCommand,
-		deployCommand,
-		detectCommand,
-		// inspectCommand,
-		loginCommand,
-		logoutCommand,
-		pullCommand,
-		versionCommand,
-		documentCommand(app),
-	}
-	app.Before = func(ctx *cli.Context) error {
-		if ctx.GlobalBool("debug") {
-			util.RootLogger().Formatter = &util.VerboseFormatter{}
-			util.RootLogger().SetLevel("debug")
-		} else {
-			util.RootLogger().Formatter = &util.TerseFormatter{}
-			util.RootLogger().SetLevel("info")
-		}
-		if ctx.GlobalBool("journal") {
-			util.RootLogger().Hooks.Add(&journalhook.JournalHook{})
-			util.RootLogger().Out = ioutil.Discard
-		}
-		// Register the global signal handler
-		util.GlobalSigint().Register(os.Interrupt)
-		util.GlobalSigterm().Register(unix.SIGTERM)
-		return nil
-	}
-	return app
-}
 
 // SoftExit is a helper for determining when to show stack traces
 type SoftExit struct {

--- a/glide.yaml
+++ b/glide.yaml
@@ -44,6 +44,9 @@ import:
   - package: golang.org/x/sys/unix
   - package: github.com/mreiferson/go-snappystream
   - package: github.com/wercker/journalhook
+    os:
+      - darwin
+      - linux
   - package: github.com/jtacoma/uritemplates
   - package: github.com/CenturyLinkLabs/docker-reg-client
     ref:     0bb0ba20bf1a05629226c2da0fdf7a37b9f661ba
@@ -58,5 +61,8 @@ import:
   # explicitly define it :-/
   - package: github.com/vaughan0/go-ini
   - package: github.com/coreos/go-systemd
+    os:
+      - darwin
+      - linux
     ref: d08b1d0cf9e96bf287b33d3a2c55132e185b273b
     vcs: git


### PR DESCRIPTION
This PR is the beginning of work to address #53. I'm not sure I have the glide.yaml totally correct, because though it properly does not checkout the dependencies, it then complains that i can't update the commits correctly. But it correctly installs everything else, and `go build` successfully creates a `wercker.exe`, which I've been able to run against my local docker-machine.

Main concerns here are code-duplication; I don't have the changes factored as well as could be to remove redundancy between windows and non-windows versions of things. It's a judgement call on your end if you'd like more effort there. Comments welcome, and I'll continue to add improvements to this PR.
