### PR TITLE
add checkpointing and base-path

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -40,6 +40,7 @@ var (
 		cli.StringFlag{Name: "docker-cert-path", Value: "", Usage: "Docker api cert path.", EnvVar: "DOCKER_CERT_PATH"},
 		cli.StringSliceFlag{Name: "docker-dns", Value: &cli.StringSlice{0: "8.8.8.8", 1: "8.8.4.4"}, Usage: "Docker DNS server.", EnvVar: "DOCKER_DNS", Hidden: true},
 		cli.BoolFlag{Name: "docker-local", Usage: "Don't interact with remote repositories"},
+		cli.StringFlag{Name: "checkpoint", Value: "", Usage: "Skip to the next step after a recent build checkpoint."},
 	}
 
 	// These flags control where we store local files

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -965,7 +965,21 @@ func executePipeline(cmdCtx context.Context, options *core.PipelineOptions, dock
 	// stepCounter starts at 3, step 1 is "get code", step 2 is "setup
 	// environment".
 	stepCounter := &util.Counter{Current: 3}
+	checkpoint := false
 	for _, step := range pipeline.Steps() {
+		// we always want to run the wercker-init step to provide some functions
+		if !checkpoint && stepCounter.Current > 3 {
+			if options.EnableDevSteps && options.Checkpoint != "" {
+				logger.Printf(f.Info("Skipping step", step.DisplayName()))
+				// start at the one after the checkpoint
+				if step.Checkpoint() == options.Checkpoint {
+					logger.Printf(f.Info("Found checkpoint", options.Checkpoint))
+					checkpoint = true
+				}
+				stepCounter.Increment()
+				continue
+			}
+		}
 		logger.Printf(f.Info("Running step", step.DisplayName()))
 		timer.Reset()
 		sr, err := r.RunStep(shared, step, stepCounter.Increment())
@@ -977,13 +991,18 @@ func executePipeline(cmdCtx context.Context, options *core.PipelineOptions, dock
 			break
 		}
 
+		if options.EnableDevSteps && step.Checkpoint() != "" {
+			logger.Printf(f.Info("Checkpointing", step.Checkpoint()))
+			box.Commit(box.Repository(), fmt.Sprintf("w-%s", step.Checkpoint()), "checkpoint", false)
+		}
+
 		if options.Verbose {
 			logger.Printf(f.Success("Step passed", step.DisplayName(), timer.String()))
 		}
 	}
 
 	if options.ShouldCommit {
-		_, err = box.Commit(repoName, tag, message)
+		_, err = box.Commit(repoName, tag, message, true)
 		if err != nil {
 			logger.Errorln("Failed to commit:", err.Error())
 		}
@@ -1143,7 +1162,6 @@ func executePipeline(cmdCtx context.Context, options *core.PipelineOptions, dock
 		if options.Verbose {
 			logger.Printf(f.Success("Exported Cache", timer.String()))
 		}
-
 	}
 
 	if pr.Success {

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -483,6 +483,7 @@ func (p *Runner) SetupEnvironment(runnerCtx context.Context) (*RunnerShared, err
 		sr.Message = err.Error()
 		return shared, err
 	}
+
 	// TODO(termie): dump some logs about the image
 	shared.box = box
 	if p.options.Verbose {
@@ -691,5 +692,6 @@ func (p *Runner) RunStep(shared *RunnerShared, step core.Step, order int) (*Step
 	if !sr.Success {
 		return sr, fmt.Errorf("Step failed with exit code: %d", sr.ExitCode)
 	}
+
 	return sr, nil
 }

--- a/core/box.go
+++ b/core/box.go
@@ -28,9 +28,10 @@ type BoxOptions struct {
 type Box interface {
 	GetName() string
 	GetTag() string
+	Repository() string
 	Clean() error
 	Stop()
-	Commit(string, string, string) (*docker.Image, error)
+	Commit(string, string, string, bool) (*docker.Image, error)
 	Restart() (*docker.Container, error)
 	AddService(ServiceBox)
 	Fetch(context.Context, *util.Environment) (*docker.Image, error)

--- a/core/config.go
+++ b/core/config.go
@@ -21,8 +21,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/wercker/wercker/util"
 	"gopkg.in/yaml.v2"
+
+	"github.com/wercker/wercker/util"
 )
 
 // RawBoxConfig is the unwrapper for BoxConfig
@@ -68,10 +69,11 @@ type RawStepConfig struct {
 
 // StepConfig holds our step configs
 type StepConfig struct {
-	ID   string
-	Cwd  string
-	Name string
-	Data map[string]string
+	ID         string
+	Cwd        string
+	Name       string
+	Data       map[string]string
+	Checkpoint string
 }
 
 // ifaceToString takes a value from yaml and makes it a string (currently
@@ -149,6 +151,10 @@ func (r *RawStepConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		r.Name = v
 		delete(stepData, "name")
 	}
+	if v, ok := stepData["checkpoint"]; ok {
+		r.Checkpoint = v
+		delete(stepData, "checkpoint")
+	}
 	r.Data = stepData
 	return nil
 }
@@ -171,6 +177,7 @@ type PipelineConfig struct {
 	AfterSteps RawStepsConfig `yaml:"after-steps"`
 	StepsMap   map[string][]*RawStepConfig
 	Services   []*RawBoxConfig `yaml:"services"`
+	BasePath   string          `yaml:"base-path"`
 }
 
 var pipelineReservedWords = map[string]struct{}{
@@ -178,6 +185,7 @@ var pipelineReservedWords = map[string]struct{}{
 	"services":    struct{}{},
 	"steps":       struct{}{},
 	"after-steps": struct{}{},
+	"base-path":   struct{}{},
 }
 
 // UnmarshalYAML in this case is a little involved due to the myriad shapes our

--- a/core/step.go
+++ b/core/step.go
@@ -89,6 +89,7 @@ type Step interface {
 	SafeID() string
 	Version() string
 	ShouldSyncEnv() bool
+	Checkpoint() string
 
 	// Actual methods
 	Fetch() (string, error)
@@ -112,6 +113,7 @@ type BaseStepOptions struct {
 	SafeID      string
 	Version     string
 	Cwd         string
+	Checkpoint  string
 }
 
 // BaseStep type for extending
@@ -124,6 +126,7 @@ type BaseStep struct {
 	safeID      string
 	version     string
 	cwd         string
+	checkpoint  string
 }
 
 func NewBaseStep(args BaseStepOptions) *BaseStep {
@@ -136,6 +139,7 @@ func NewBaseStep(args BaseStepOptions) *BaseStep {
 		safeID:      args.SafeID,
 		version:     args.Version,
 		cwd:         args.Cwd,
+		checkpoint:  args.Checkpoint,
 	}
 }
 
@@ -177,6 +181,11 @@ func (s *BaseStep) SafeID() string {
 // Version getter
 func (s *BaseStep) Version() string {
 	return s.version
+}
+
+// Version getter
+func (s *BaseStep) Checkpoint() string {
+	return s.checkpoint
 }
 
 // ExternalStep is the holder of the Step methods.
@@ -262,6 +271,7 @@ func NewStep(stepConfig *StepConfig, options *PipelineOptions) (*ExternalStep, e
 			safeID:      stepSafeID,
 			version:     version,
 			cwd:         stepConfig.Cwd,
+			checkpoint:  stepConfig.Checkpoint,
 		},
 		options: options,
 		data:    data,

--- a/docker/box.go
+++ b/docker/box.go
@@ -70,6 +70,10 @@ func NewDockerBox(boxConfig *core.BoxConfig, options *core.PipelineOptions, dock
 	if boxConfig.Tag != "" {
 		tag = boxConfig.Tag
 	}
+	// checkpoint support
+	if options.Checkpoint != "" {
+		tag = fmt.Sprintf("w-%s", options.Checkpoint)
+	}
 	name = fmt.Sprintf("%s:%s", repository, tag)
 
 	repoParts := strings.Split(repository, "/")
@@ -132,6 +136,10 @@ func (b *DockerBox) Link() string {
 // GetName gets the box name
 func (b *DockerBox) GetName() string {
 	return b.Name
+}
+
+func (b *DockerBox) Repository() string {
+	return b.repository
 }
 
 func (b *DockerBox) GetTag() string {
@@ -549,7 +557,7 @@ func (b *DockerBox) Fetch(ctx context.Context, env *util.Environment) (*docker.I
 }
 
 // Commit the current running Docker container to an Docker image.
-func (b *DockerBox) Commit(name, tag, message string) (*docker.Image, error) {
+func (b *DockerBox) Commit(name, tag, message string, cleanup bool) (*docker.Image, error) {
 	b.logger.WithFields(util.LogFields{
 		"Name": name,
 		"Tag":  tag,
@@ -570,7 +578,9 @@ func (b *DockerBox) Commit(name, tag, message string) (*docker.Image, error) {
 		return nil, err
 	}
 
-	b.images = append(b.images, image)
+	if cleanup {
+		b.images = append(b.images, image)
+	}
 
 	return image, nil
 }

--- a/docker/build.go
+++ b/docker/build.go
@@ -107,7 +107,7 @@ func (b *DockerBuild) CollectArtifact(containerID string) (*core.Artifact, error
 
 	sourceArtifact := &core.Artifact{
 		ContainerID:   containerID,
-		GuestPath:     b.options.SourcePath(),
+		GuestPath:     b.options.BasePath(),
 		HostPath:      b.options.HostPath("output"),
 		HostTarPath:   b.options.HostPath("output.tar"),
 		ApplicationID: b.options.ApplicationID,

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -713,7 +713,7 @@ func (s *DockerScratchPushStep) CollectArtifact(containerID string) (*core.Artif
 
 	sourceArtifact := &core.Artifact{
 		ContainerID:   containerID,
-		GuestPath:     s.options.SourcePath(),
+		GuestPath:     s.options.BasePath(),
 		HostPath:      s.options.HostPath("layer"),
 		HostTarPath:   s.options.HostPath("layer.tar"),
 		ApplicationID: s.options.ApplicationID,

--- a/docker/pipeline.go
+++ b/docker/pipeline.go
@@ -114,6 +114,7 @@ func NewDockerPipeline(name string, config *core.Config, options *core.PipelineO
 	logger := util.RootLogger().WithField("Logger", "Pipeline")
 	base := core.NewBasePipeline(core.BasePipelineOptions{
 		Options:    options,
+		Config:     pipelineConfig.PipelineConfig,
 		Env:        util.NewEnvironment(),
 		Box:        box,
 		Services:   services,

--- a/test-all.sh
+++ b/test-all.sh
@@ -113,6 +113,11 @@ runTests() {
   basicTest "local deploy using specific build not containing wercker.yml" deploy --docker-local ./last_build || return 1
   cd "$testsDir/local-deploy/specific-yml"
   basicTest "local deploy using specific build containing wercker.yml" deploy --docker-local ./last_build || return 1
+
+  # test checkpointers
+  basicTest "checkpoint, part 1" build --docker-local --enable-dev-steps "$testsDir/checkpoint" || return 1
+  basicTestFail "checkpoint, part 2" build --docker-local --checkpoint foo "$testsDir/checkpoint" || return 1
+  basicTest "checkpoint, part 3" build --docker-local --enable-dev-steps --checkpoint foo "$testsDir/checkpoint" || return 1
 }
 
 runTests

--- a/tests/projects/checkpoint/wercker.yml
+++ b/tests/projects/checkpoint/wercker.yml
@@ -1,0 +1,22 @@
+build:
+  box:
+    id: alpine
+    cmd: /bin/sh
+  steps:
+    - script:
+        name: check that we have not already checkpointed
+        code: |
+          if [ -e "/foo" ]; then
+            return false
+          fi
+    - script:
+        checkpoint: foo
+        name: touch a file
+        code: touch /foo
+    - script:
+        name: check that we have the file we touched
+        code: |
+          if [ ! -e "/foo" ]; then
+            return false
+          fi
+

--- a/wercker.yml
+++ b/wercker.yml
@@ -16,26 +16,30 @@ dev:
           echo "welcome to your shell"
           echo "stay a while, and listen"
 build:
+  # base-path: /gopath/src/github.com/wercker/wercker
   steps:
     - install-packages:
+        checkpoint: pkgs
         packages: openssh-client pkg-config libsystemd-journal-dev
-
-    - add-to-known_hosts:
-        hostname: github.com
-        fingerprint: "16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48"
 
     - setup-go-workspace:
         package-dir: github.com/wercker/wercker
 
     - script:
+        checkpoint: deps
         name: glide install
         code: |
           export GO15VENDOREXPERIMENT=1
           export GLIDE_VERSION=0.8.3
           curl -LO https://github.com/Masterminds/glide/releases/download/${GLIDE_VERSION}/glide-${GLIDE_VERSION}-linux-amd64.tar.gz
           tar -xvzf glide-${GLIDE_VERSION}-linux-amd64.tar.gz
-          cp linux-amd64/glide ./
-          ./glide install --quick
+          cp linux-amd64/glide /bin/glide
+          glide install --quick
+
+    - script:
+        code: |
+          export GO15VENDOREXPERIMENT=1
+          export GLIDE_VERSION=0.8.3
 
     - script:
         name: go vet
@@ -52,7 +56,7 @@ build:
 
     - script:
         name: go test
-        code: go test $(./glide novendor)
+        code: go test $(glide novendor)
 
     - script:
         name: clear out the build binaries


### PR DESCRIPTION
base-path lets us get around many of the issues that setup-go-workspace ran
into due to having the change the name of the working dir, it can be set as
a field on a pipeline

checkpointing adds the ability to set checkpoints at steps causing the
container to get locally committed and adds a flag "--checkpoint" that will
cause the build to resume from that commit

also changed is we now remove the "source" path if it already existed in
the container, allowing builds to be chained a bit more easily