### PR TITLE
bumps s3 dependency

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -52,8 +52,6 @@ import:
   - package: gopkg.in/fsnotify.v1
   - package: github.com/cheggaaa/pb
   - package: github.com/aws/aws-sdk-go
-    ref:     v0.9.7
-    vcs:     git
   # this is dependency of aws-sdk-go, but glide doesn't install it unless you
   # explicitly define it :-/
   - package: github.com/vaughan0/go-ini


### PR DESCRIPTION
we need to bump our aws-sdk-go dependency in order to be able to use the [check access library] (https://github.com/wercker/docker-check-access)

relatively simple stuff has changed between the two versions, mostly regarding how you set up an uploader