### PR TITLE
Output a descriptive error message when setup environment fails

### DIFF
--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -215,11 +215,11 @@ func (p *BasePipeline) SetupGuest(sessionCtx context.Context, sess *Session) err
 	p.logger.Printf(f.Info("Copying source to container"))
 	for _, cmd := range cmds {
 		exit, _, err := sess.SendChecked(sessionCtx, cmd)
+		if exit != 0 {
+			return fmt.Errorf("Guest command failed with exit code %d: %s", exit, cmd)
+		}
 		if err != nil {
 			return err
-		}
-		if exit != 0 {
-			return fmt.Errorf("Guest command failed: %s", cmd)
 		}
 	}
 	if p.options.Verbose {


### PR DESCRIPTION
The problem occurred with a docker base image where mkdir /pipeline fails.

WIthout this patch the output is just that "something" failed with exit code 1. - especially annoying in the web interface when there is no easy way to enable debug.

With this patch the output is:

`Guest command failed with exit code 1: mkdir -p "/pipeline"
`