### PR TITLE
Remove github.com/docker/reference

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -59,4 +59,3 @@ import:
     ref: d08b1d0cf9e96bf287b33d3a2c55132e185b273b
     vcs: git
   - package: github.com/wercker/docker-check-access
-  - package: github.com/docker/docker/reference


### PR DESCRIPTION
Ran into this when building from source. `docker/reference` is not actually a package that can be installed.