### PR TITLE
Cleanup old builds, keep latest 2

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -899,6 +899,13 @@ func executePipeline(cmdCtx context.Context, options *core.PipelineOptions, dock
 		})
 		return nil, soft.Exit(err)
 	}
+	err = r.CleanupOldBuilds()
+	if err != nil {
+		e.Emit(core.Logs, &core.LogsArgs{
+			Stream: "stderr",
+			Logs:   err.Error() + "\n",
+		})
+	}
 	if options.Verbose {
 		logger.Printf(f.Success("Copied working dir", timer.String()))
 	}

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/pborman/uuid"
 	"github.com/termie/go-shutil"
@@ -252,8 +253,12 @@ func (p *Runner) CleanupOldBuilds() error {
 
 	cleanup := builds[keepDirs:]
 
+	// only clean up builds older than 24h
+	oldFile := time.Now().Add(time.Hour * -24)
 	for _, f := range cleanup {
-		os.RemoveAll(path.Join(buildPath, f.Name()))
+		if f.ModTime().Before(oldFile) {
+			os.RemoveAll(path.Join(buildPath, f.Name()))
+		}
 	}
 
 	return err

--- a/util/util.go
+++ b/util/util.go
@@ -25,6 +25,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -408,4 +409,30 @@ func (t *Timer) Elapsed() time.Duration {
 // String repr for time
 func (t *Timer) String() string {
 	return fmt.Sprintf("%.2fs", t.Elapsed().Seconds())
+}
+
+// ByModifiedTime is used for sorting files/folders by mod time
+type ByModifiedTime []os.FileInfo
+
+// Len, Swap and Less are used for sorting
+
+// Len returns the length of items in the slice
+func (s ByModifiedTime) Len() int {
+	return len(s)
+}
+
+// Swap swaps two items when sorting
+func (s ByModifiedTime) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less returns true if the first value shoudl appear first in the
+// sorted results
+func (s ByModifiedTime) Less(i, j int) bool {
+	return s[i].ModTime().After(s[j].ModTime())
+}
+
+// SortByModDate sorts the files or folders descending by modification date
+func SortByModDate(dirs []os.FileInfo) {
+	sort.Sort(ByModifiedTime(dirs))
 }


### PR DESCRIPTION
This cleans up old build artifacts from `.wercker/builds`. The latest 2, sorted by modification date, are left intact.

This fixes #165