### PR TITLE
recommend homebrew upgrade when installed with homebrew

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -773,18 +773,18 @@ func cmdVersion(options *core.VersionOptions) error {
 				updater.ServerVersion.FullVersion())
 
 			// try to determine if binary was installed with homebrew
-			// ignore potential error; an error would mean we can't be sure
-			// so optimize for happy-path
-			homebrew, _ := util.InstalledWithHomebrew()
+			homebrew := util.InstalledWithHomebrew()
 
 			if homebrew {
 				logger.Info("\nLooks like wercker was installed with homebrew.\n\n" +
 					"To update to the latest version please use:\n" +
-					"brew upgrade wercker-cli")
-				os.Exit(1)
+					"brew update && brew upgrade wercker-cli")
+
+				logger.Println("\nUsing the built in updater can cause issues with Wercker installed with homebrew.")
+			} else {
+				logger.Infoln("Download it from:", updater.DownloadURL())
 			}
 
-			logger.Infoln("Download it from:", updater.DownloadURL())
 			if AskForUpdate() {
 				if err := updater.Update(); err != nil {
 					logger.WithField("Error", err).Warn(

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -739,6 +739,7 @@ func emitProgress(counter *util.CounterReader, total int64, logger *util.Logger)
 
 func cmdVersion(options *core.VersionOptions) error {
 	logger := util.RootLogger().WithField("Logger", "Main")
+
 	v := util.GetVersions()
 
 	if options.OutputJSON {
@@ -770,6 +771,19 @@ func cmdVersion(options *core.VersionOptions) error {
 		if updater.UpdateAvailable() {
 			logger.Infoln("A new version is available:",
 				updater.ServerVersion.FullVersion())
+
+			// try to determine if binary was installed with homebrew
+			// ignore potential error; an error would mean we can't be sure
+			// so optimize for happy-path
+			homebrew, _ := util.InstalledWithHomebrew()
+
+			if homebrew {
+				logger.Info("\nLooks like wercker was installed with homebrew.\n\n" +
+					"To update to the latest version please use:\n" +
+					"brew upgrade wercker-cli")
+				os.Exit(1)
+			}
+
 			logger.Infoln("Download it from:", updater.DownloadURL())
 			if AskForUpdate() {
 				if err := updater.Update(); err != nil {

--- a/util/homebrew.go
+++ b/util/homebrew.go
@@ -1,81 +1,17 @@
 package util
 
-import (
-	"os/exec"
-	"path"
-	"path/filepath"
-	"regexp"
-	"strings"
-
-	"github.com/kardianos/osext"
-)
+import "os/exec"
 
 // InstalledWithHomebrew tries to determine if the cli was installed with homebrew
-// Returns true if installed and currently running, empty string if not installed
-//
-// Heuristic (bail if any step fails):
-//   1. see if homebrew is installed
-//   2. get installed packages from homebrew, look for `wercker-cli`
-//   3. find symlink installed by homebrew, follow it to binary
-//   4. get path of currently running executable
-//   5. compare path with homebrew path
-func InstalledWithHomebrew() (bool, error) {
+func InstalledWithHomebrew() bool {
 	// Check if homebrew is installed
-	cmd := exec.Command("which", "brew")
-	cmdOut, err := cmd.Output()
+	cmd := exec.Command("brew", "info", "wercker-cli")
+	err := cmd.Start()
 	if err != nil {
-		return false, err
+		// if homebrew is not installed this will fail -> we know wercker was not installed with homebrew
+		// if the brew command succeeds but the wercker-cli is not installed it will exit with code 1
+		return false
 	}
 
-	if string(cmdOut) == "homebrew not found" {
-		// Homebrew not installed on machine
-		return false, nil
-	}
-
-	// Check if wercker was installed with homebrew
-	cmd = exec.Command("brew", "list", "--versions")
-	cmdOut, err = cmd.Output()
-	if err != nil {
-		return false, err
-	}
-
-	version := string(cmdOut)
-	r := regexp.MustCompile(`(?m)^wercker-cli\s(.*)$`)
-	matches := r.FindAllStringSubmatch(version, -1)
-
-	if len(matches) == 0 {
-		// wercker not installed in homebrew
-		return false, nil
-	}
-
-	// resolve path to installed homebrew binary
-	cmd = exec.Command("brew", "--prefix")
-	cmdOut, err = cmd.Output()
-	if err != nil {
-		return false, err
-	}
-
-	brewPath := strings.Trim(string(cmdOut), "\n ")
-	brewBinary := path.Join(brewPath, "/bin/wercker")
-	brewBinPath, err := filepath.EvalSymlinks(brewBinary)
-
-	if err != nil {
-		// could not resolve symlink
-		// could happen if {brew prefix}/bin/wercker doesn't exist
-		return false, err
-	}
-
-	// get path of currently running executable
-	curPath, err := osext.Executable()
-	if err != nil {
-		return false, err
-	}
-
-	if curPath == brewBinPath {
-		// current executable path matches binary installed by homebrew
-		return true, nil
-	}
-
-	// path didn't match -> this binary was not from homebrew
-	return false, nil
+	return true
 }

--- a/util/homebrew.go
+++ b/util/homebrew.go
@@ -6,7 +6,7 @@ import "os/exec"
 func InstalledWithHomebrew() bool {
 	// Check if homebrew is installed
 	cmd := exec.Command("brew", "info", "wercker-cli")
-	err := cmd.Start()
+	err := cmd.Run()
 	if err != nil {
 		// if homebrew is not installed this will fail -> we know wercker was not installed with homebrew
 		// if the brew command succeeds but the wercker-cli is not installed it will exit with code 1

--- a/util/homebrew.go
+++ b/util/homebrew.go
@@ -1,0 +1,81 @@
+package util
+
+import (
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/kardianos/osext"
+)
+
+// InstalledWithHomebrew tries to determine if the cli was installed with homebrew
+// Returns true if installed and currently running, empty string if not installed
+//
+// Heuristic (bail if any step fails):
+//   1. see if homebrew is installed
+//   2. get installed packages from homebrew, look for `wercker-cli`
+//   3. find symlink installed by homebrew, follow it to binary
+//   4. get path of currently running executable
+//   5. compare path with homebrew path
+func InstalledWithHomebrew() (bool, error) {
+	// Check if homebrew is installed
+	cmd := exec.Command("which", "brew")
+	cmdOut, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+
+	if string(cmdOut) == "homebrew not found" {
+		// Homebrew not installed on machine
+		return false, nil
+	}
+
+	// Check if wercker was installed with homebrew
+	cmd = exec.Command("brew", "list", "--versions")
+	cmdOut, err = cmd.Output()
+	if err != nil {
+		return false, err
+	}
+
+	version := string(cmdOut)
+	r := regexp.MustCompile(`(?m)^wercker-cli\s(.*)$`)
+	matches := r.FindAllStringSubmatch(version, -1)
+
+	if len(matches) == 0 {
+		// wercker not installed in homebrew
+		return false, nil
+	}
+
+	// resolve path to installed homebrew binary
+	cmd = exec.Command("brew", "--prefix")
+	cmdOut, err = cmd.Output()
+	if err != nil {
+		return false, err
+	}
+
+	brewPath := strings.Trim(string(cmdOut), "\n ")
+	brewBinary := path.Join(brewPath, "/bin/wercker")
+	brewBinPath, err := filepath.EvalSymlinks(brewBinary)
+
+	if err != nil {
+		// could not resolve symlink
+		// could happen if {brew prefix}/bin/wercker doesn't exist
+		return false, err
+	}
+
+	// get path of currently running executable
+	curPath, err := osext.Executable()
+	if err != nil {
+		return false, err
+	}
+
+	if curPath == brewBinPath {
+		// current executable path matches binary installed by homebrew
+		return true, nil
+	}
+
+	// path didn't match -> this binary was not from homebrew
+	return false, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -712,12 +712,6 @@
 			"revisionTime": "2016-01-05T22:08:40Z"
 		},
 		{
-			"checksumSHA1": "0USxm725IUV4xoFomgvWhJe4vLY=",
-			"path": "github.com/kardianos/osext",
-			"revision": "29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc",
-			"revisionTime": "2015-12-22T15:32:29Z"
-		},
-		{
 			"checksumSHA1": "c079Nyaher72rGrFsWM9AaWxCsU=",
 			"path": "github.com/mattn/go-colorable",
 			"revision": "bc69d6cebca8dd5675346a34a1c545b67dc74d5e",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -712,6 +712,12 @@
 			"revisionTime": "2016-01-05T22:08:40Z"
 		},
 		{
+			"checksumSHA1": "0USxm725IUV4xoFomgvWhJe4vLY=",
+			"path": "github.com/kardianos/osext",
+			"revision": "29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc",
+			"revisionTime": "2015-12-22T15:32:29Z"
+		},
+		{
 			"checksumSHA1": "c079Nyaher72rGrFsWM9AaWxCsU=",
 			"path": "github.com/mattn/go-colorable",
 			"revision": "bc69d6cebca8dd5675346a34a1c545b67dc74d5e",


### PR DESCRIPTION
- try to determine if wercker was installed with homebrew
- if yes and a new version is available recommend user to use `brew upgrade wercker-cli` instead of the built in upgrade mechanism