### PR TITLE
fix panic when running check-config with no box definition

### DIFF
--- a/docker/pipeline.go
+++ b/docker/pipeline.go
@@ -44,6 +44,7 @@ func NewDockerPipeline(name string, config *core.Config, options *core.PipelineO
 	if rawBoxConfig == nil {
 		rawBoxConfig = config.Box
 	}
+	// no pipeline config or global config
 	if rawBoxConfig == nil {
 		return nil, fmt.Errorf("No box definition found")
 	}

--- a/docker/pipeline.go
+++ b/docker/pipeline.go
@@ -44,6 +44,9 @@ func NewDockerPipeline(name string, config *core.Config, options *core.PipelineO
 	if rawBoxConfig == nil {
 		rawBoxConfig = config.Box
 	}
+	if rawBoxConfig == nil {
+		return nil, fmt.Errorf("No box definition found")
+	}
 	boxConfig := rawBoxConfig.BoxConfig
 
 	// Select this pipeline's service or the global config


### PR DESCRIPTION
Fixes panic when trying to run the `check-config` command without a box definition