### PR TITLE
fix multiline env vars

### DIFF
--- a/util/environment.go
+++ b/util/environment.go
@@ -74,7 +74,13 @@ func (e *Environment) Get(key string) string {
 func (e *Environment) Export() []string {
 	s := []string{}
 	for _, key := range e.Order {
-		s = append(s, fmt.Sprintf(`export %s=%q`, key, e.Map[key]))
+		val := e.Map[key]
+		if strings.Contains(val, "\n") {
+			// multiline string, need to wrap in '
+			s = append(s, fmt.Sprintf(`export %s='%s'`, key, val))
+		} else {
+			s = append(s, fmt.Sprintf(`export %s=%q`, key, val))
+		}
 	}
 	return s
 }

--- a/util/environment_test.go
+++ b/util/environment_test.go
@@ -68,3 +68,9 @@ func (s *EnvironmentSuite) TestExport() {
 	expected := []string{`export PUBLIC="foo"`, `export X_PRIVATE="zed"`}
 	s.Equal(env.Export(), expected)
 }
+
+func (s *EnvironmentSuite) TestExportMultiline() {
+	env := NewEnvironment("MULTI=a\nb\nc", "SINGLE=abc")
+	expected := []string{"export MULTI='a\nb\nc'", "export SINGLE=\"abc\""}
+	s.Equal(env.Export(), expected)
+}


### PR DESCRIPTION
If the env vars contain a linebreak it will not come through correctly (will show up as `\n`). This should fix it by setting env vars `export KEY='multi\nline\nvalue'` (wrapped in single quotes).

1. Tested to work with something like this in an ENVIRONMENT file:
```
X_MULTILINE="this\nis\nover\nmultiple\nlines"
```

...and running the build like this:

```bash
wercker --environment ENVIRONMENT build
```

2. However this _does not_ work (result shows `\n`):
```
X_MULTILINE="this\nis\nover\nmultiple\nlines\ntoo" wercker build
```

3. This also shows `\n`:
```bash
export X_MULTILINE="this\nis\nover\nmultiple\nlines\ntoo" wercker build
wercker build
```

I'm not sure how the env vars are actually set when not running locally, might be that the solution for 1 is not sufficient?

Here's a wercker.yml to see the output:
```yml
box: golang:1.6
build:
  steps:
    - script:
        code: |
          echo "Multi:"
          echo "$MULTILINE"
```
Notice the double quote, otherwise the multiline string will be split by spaces