### PR TITLE
[WIP] Push to v2 registry by default

### DIFF
--- a/auth/auth_helper.go
+++ b/auth/auth_helper.go
@@ -31,7 +31,7 @@ func NormalizeRegistry(address string) string {
 	logger := util.RootLogger().WithField("Logger", "Docker")
 	if address == "" {
 		logger.Debugln("No registry address provided, using https://registry.hub.docker.com")
-		return "https://registry.hub.docker.com/v1/"
+		return "https://registry.hub.docker.com/v2/"
 	}
 
 	parsed, err := url.Parse(address)
@@ -56,9 +56,9 @@ func NormalizeRegistry(address string) string {
 	parts := strings.Split(address, "/")
 	possiblyAPIVersionStr := parts[len(parts)-1]
 
-	// send them a v1 registry if they don't specify
+	// send them a v2 registry if they don't specify
 	if possiblyAPIVersionStr != "v1" && possiblyAPIVersionStr != "v2" {
-		newParts := append(parts, "v1")
+		newParts := append(parts, "v2")
 		address = strings.Join(newParts, "/")
 	}
 	return address + "/"

--- a/auth/auth_helper_test.go
+++ b/auth/auth_helper_test.go
@@ -12,19 +12,19 @@ type AuthHelperSuite struct {
 }
 
 func (a *AuthHelperSuite) TestNormalizeRegistry() {
-	quay := "https://quay.io/v1/"
-	dock := "https://registry.hub.docker.com/v1/"
+	quay := "https://quay.io/v2/"
+	dock := "https://registry.hub.docker.com/v2/"
 	a.Equal(quay, NormalizeRegistry("https://quay.io"))
-	a.Equal(quay, NormalizeRegistry("https://quay.io/v1"))
-	a.Equal(quay, NormalizeRegistry("http://quay.io/v1"))
-	a.Equal(quay, NormalizeRegistry("https://quay.io/v1/"))
+	a.Equal(quay, NormalizeRegistry("https://quay.io/v2"))
+	a.Equal(quay, NormalizeRegistry("http://quay.io/v2"))
+	a.Equal(quay, NormalizeRegistry("https://quay.io/v2/"))
 	a.Equal(quay, NormalizeRegistry("quay.io"))
 
 	a.Equal(dock, NormalizeRegistry(""))
 	a.Equal(dock, NormalizeRegistry("https://registry.hub.docker.com"))
 	a.Equal(dock, NormalizeRegistry("http://registry.hub.docker.com"))
 	a.Equal(dock, NormalizeRegistry("registry.hub.docker.com"))
-	a.Equal("https://quay.io/v2/", NormalizeRegistry("quay.io/v2/"))
+	a.Equal("https://quay.io/v1/", NormalizeRegistry("quay.io/v1/"))
 	a.Equal("https://registry-1.docker.io/v2/", NormalizeRegistry("registry-1.docker.io"))
 }
 

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -78,7 +78,7 @@ func (s *ConfigSuite) TestConfigBoxStructs() {
 	_, ok = authenticator.(*auth.AmazonAuth)
 	s.Equal(ok, true)
 
-	docker := config.PipelinesMap["docker-v2"]
+	docker := config.PipelinesMap["docker"]
 	assert.NotNil(s.T(), docker.Box.Auth)
 	_, ok = docker.Box.Auth.(*DockerAuth)
 	s.Equal(ok, true)
@@ -86,7 +86,7 @@ func (s *ConfigSuite) TestConfigBoxStructs() {
 	_, ok = authenticator.(*auth.DockerAuth)
 	s.Equal(ok, true)
 
-	dockerV1 := config.PipelinesMap["docker"]
+	dockerV1 := config.PipelinesMap["docker-v1"]
 	assert.NotNil(s.T(), dockerV1.Box.Auth)
 	_, ok = dockerV1.Box.Auth.(*DockerAuth)
 	s.Equal(ok, true)


### PR DESCRIPTION
Resolves #180. 

This changes the default behaviour when pulling and pushing containers to automatically use `v2` API registries instead of `v1`. If someone needs to force `v1` they can simply append that to their registry URL, e.g:

```
- internal/docker-push:
  username: $username
  password: $password
  repository: my-registry/$repository
  registry: https://my-registry/v1
```

Todo:
- [ ] Fix tests
