### PR TITLE
Fix failing chained runs (based on runs)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ## unreleased
 
 - Add additional output when storing artifacts (#207)
+- fix longer (2+) chains of runs tha have source-dir specified (#151)
 
 ## v1.0.560 (2016-07-14)
 

--- a/docker/deploy.go
+++ b/docker/deploy.go
@@ -118,7 +118,7 @@ func (d *DockerDeploy) CollectArtifact(containerID string) (*core.Artifact, erro
 
 	sourceArtifact := &core.Artifact{
 		ContainerID:   containerID,
-		GuestPath:     d.options.SourcePath(),
+		GuestPath:     d.options.BasePath(),
 		HostPath:      d.options.HostPath("output"),
 		HostTarPath:   d.options.HostPath("output.tar"),
 		ApplicationID: d.options.ApplicationID,


### PR DESCRIPTION
The bug only happened when source-dir was used. The deploy like runs
would use the dir specified by source-dir as the output, causing
subsequent runs to fail because it's likely that the dir specified by
source-dir would not exist there.

The behaviour for collecting data should now be the same for deploys
as it is for builds

resolves #151