### PR TITLE
handle rm -rf /pipeline

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1075,6 +1075,9 @@ func executePipeline(cmdCtx context.Context, options *core.PipelineOptions, dock
 				ignoredDirectories := []string{".git", "node_modules", "vendor", "site-packages"}
 				nameEmit := func(path string, info os.FileInfo, err error) error {
 					relativePath := strings.TrimPrefix(path, artifact.HostPath)
+					if info == nil {
+						return nil
+					}
 
 					if info.IsDir() {
 						if util.ContainsString(ignoredDirectories, info.Name()) {

--- a/test-all.sh
+++ b/test-all.sh
@@ -85,6 +85,7 @@ testScratchPush () {
 
 runTests() {
   basicTest "source-path" build "$testsDir/source-path" || return 1
+  basicTest "rm pipeline" build --artifacts "$testsDir/rm-pipeline" || return 1
   basicTest "local services" build "$testsDir/local-service/service-consumer" || return 1
   basicTest "deploy" deploy "$testsDir/deploy-no-targets" --docker-local || return 1
   basicTest "deploy target" deploy --deploy-target test "$testsDir/deploy-targets" --docker-local || return 1

--- a/tests/projects/rm-pipeline/wercker.yml
+++ b/tests/projects/rm-pipeline/wercker.yml
@@ -1,0 +1,9 @@
+box:
+  id: alpine
+  cmd: /bin/sh
+build:
+  steps:
+    - script:
+        name: prune
+        code: rm -rf /pipeline
+


### PR DESCRIPTION
Seems to work

```
--> Running step: prune
--> Running step: docker push
Pushing image for tag  differentiate_envs-0b97c3fd028c1c94779fd247e0ec6f8ea504272f-staging
Storing artifacts
Collecting files from /pipeline/output
Total artifact size: 0 B
Storing artifacts complete
```