### PR TITLE
Add --pipeline to the wercker --help visible output

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -182,6 +182,7 @@ var (
 		cli.Float64Flag{Name: "no-response-timeout", Value: 5, Usage: "Timeout if no script output is received in this many minutes."},
 		cli.Float64Flag{Name: "command-timeout", Value: 25, Usage: "Timeout if command does not complete in this many minutes."},
 		cli.StringFlag{Name: "wercker-yml", Value: "", Usage: "Specify a specific yaml file.", EnvVar: "WERCKER_YML_FILE"},
+		cli.StringFlag{Name: "pipeline", Value: "", EnvVar: "WERCKER_PIPELINE", Usage: "Alternate pipeline name to execute."},
 	}
 
 	PullFlagSet = [][]cli.Flag{

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -71,8 +71,7 @@ var (
 			Usage: "The application owner name."},
 		cli.StringFlag{Name: "application-started-by-name", Value: "", EnvVar: "WERCKER_APPLICATION_STARTED_BY_NAME", Hidden: true,
 			Usage: "The name of the user who started the application."},
-		cli.StringFlag{Name: "pipeline", Value: "", EnvVar: "WERCKER_PIPELINE", Hidden: true,
-			Usage: "Alternate pipeline name to execute."},
+		cli.StringFlag{Name: "pipeline", Value: "", EnvVar: "WERCKER_PIPELINE", Usage: "Alternate pipeline name to execute."},
 	}
 
 	GitFlags = []cli.Flag{
@@ -182,7 +181,6 @@ var (
 		cli.Float64Flag{Name: "no-response-timeout", Value: 5, Usage: "Timeout if no script output is received in this many minutes."},
 		cli.Float64Flag{Name: "command-timeout", Value: 25, Usage: "Timeout if command does not complete in this many minutes."},
 		cli.StringFlag{Name: "wercker-yml", Value: "", Usage: "Specify a specific yaml file.", EnvVar: "WERCKER_YML_FILE"},
-		cli.StringFlag{Name: "pipeline", Value: "", EnvVar: "WERCKER_PIPELINE", Usage: "Alternate pipeline name to execute."},
 	}
 
 	PullFlagSet = [][]cli.Flag{


### PR DESCRIPTION
Small change to flags to add cli visible help for the pipeline flag. #234 