### PR TITLE
adds a run id field for easier analysis on logs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -866,7 +866,7 @@ func executePipeline(cmdCtx context.Context, options *core.PipelineOptions, dock
 	// Boilerplate
 	soft := NewSoftExit(options.GlobalOptions)
 	logger := util.RootLogger().WithField("Logger", "Main")
-	logger = logger.WithField("RunID", options.RunID)
+	logger = util.RootLogger().WithField("RunID", options.RunID)
 	e, err := core.EmitterFromContext(cmdCtx)
 	if err != nil {
 		return nil, err

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -865,8 +865,10 @@ func DumpOptions(options interface{}, indent ...string) {
 func executePipeline(cmdCtx context.Context, options *core.PipelineOptions, dockerOptions *dockerlocal.DockerOptions, getter pipelineGetter) (*RunnerShared, error) {
 	// Boilerplate
 	soft := NewSoftExit(options.GlobalOptions)
-	logger := util.RootLogger().WithField("Logger", "Main")
-	logger = util.RootLogger().WithField("RunID", options.RunID)
+	logger := util.RootLogger().WithFields(util.LogFields{
+		"Logger": "Main",
+		"RunID":  options.RunID,
+	})
 	e, err := core.EmitterFromContext(cmdCtx)
 	if err != nil {
 		return nil, err

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -866,6 +866,7 @@ func executePipeline(cmdCtx context.Context, options *core.PipelineOptions, dock
 	// Boilerplate
 	soft := NewSoftExit(options.GlobalOptions)
 	logger := util.RootLogger().WithField("Logger", "Main")
+	logger = logger.WithField("RunID", options.RunID)
 	e, err := core.EmitterFromContext(cmdCtx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
What i think this does- adds the run id of the current build for all of the logs that will happen in the build, as we are using 1 root logger. This field will be useful for quick analysis of runs later 