### PR TITLE
Fix injection of bash into empty box's cmd with overridden entrypoint

### DIFF
--- a/docker/box.go
+++ b/docker/box.go
@@ -84,12 +84,12 @@ func NewDockerBox(boxConfig *core.BoxConfig, options *core.PipelineOptions, dock
 
 	networkDisabled := false
 
+	entrypoint := boxConfig.Entrypoint
+
 	cmd := boxConfig.Cmd
-	if cmd == "" {
+	if entrypoint == "" && cmd == "" {
 		cmd = "/bin/bash"
 	}
-
-	entrypoint := boxConfig.Entrypoint
 
 	logger := util.RootLogger().WithFields(util.LogFields{
 		"Logger":    "Box",


### PR DESCRIPTION
This add extra check on `cmd` and `entrypoint` in order to have proper behaviour when overriding the entrypoint with an empty `cmd`. This should work:
```
push-quay:
  box:
    id: quay.io/wercker/cronetes
    entrypoint: /bin/sh
```

Fix #218 