### PR TITLE
Step reporter times

### DIFF
--- a/event/reporthandler.go
+++ b/event/reporthandler.go
@@ -67,7 +67,7 @@ type ReportHandler struct {
 func (h *ReportHandler) StepStarted(args *core.BuildStepStartedArgs) {
 	now := time.Now()
 	h.startStep[args.Step.SafeID()] = now
-
+	h.logger.Debugf("this is h.startStep at %s: %v ", args.Step.SafeID(), now)
 	opts := reporter.RunStepStartedArgs{
 		RunID:      args.Options.RunID,
 		StepSafeID: args.Step.SafeID(),
@@ -91,6 +91,7 @@ func (h *ReportHandler) StepFinished(args *core.BuildStepFinishedArgs) {
 
 	var duration int64
 	begin, ok := h.startStep[args.Step.SafeID()]
+	h.logger.Debugf("this is begin %v and this is ok %b \n", begin, ok)
 	if ok {
 		elapsed := now.Sub(begin)
 		duration = int64(elapsed.Seconds())

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1002,12 +1002,12 @@
 			"revisionTime": "2016-01-14T23:54:04Z"
 		},
 		{
-			"checksumSHA1": "NX0LPF1e6aVP9xNyo6X/lrJvk1Q=",
+			"checksumSHA1": "6UUCJuk3DXbOGDsni0Z90bFgIpA=",
 			"path": "github.com/wercker/reporter-client",
-			"revision": "ca90b85c7a2b9b1133d552923b51f27326dae268",
-			"revisionTime": "2016-02-12T15:29:52Z",
-			"version": "generic_pipelines",
-			"versionExact": "generic_pipelines"
+			"revision": "690f9f226f25a2526bc0e57e7968d0932c89a994",
+			"revisionTime": "2017-02-09T21:23:32Z",
+			"version": "generic_pipeline_step_times",
+			"versionExact": "generic_pipeline_step_times"
 		},
 		{
 			"checksumSHA1": "jr9CBChWOd6ZdXNikH8Hbx6PuVo=",


### PR DESCRIPTION
- adds a map to keep track of step finished event times
- sends them along using the reporter client

Note: logs will be taken out