### PR TITLE
fix missing environment for docker-scratch-push

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -383,7 +383,7 @@ func (s *DockerScratchPushStep) Execute(ctx context.Context, sess *core.Session)
 	config := &container.Config{
 		Cmd:          s.cmd,
 		Entrypoint:   s.entrypoint,
-        Env:          s.env,
+		Env:          s.env,
 		Hostname:     containerID[:16],
 		WorkingDir:   s.workingDir,
 		Volumes:      s.volumes,

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -383,6 +383,7 @@ func (s *DockerScratchPushStep) Execute(ctx context.Context, sess *core.Session)
 	config := &container.Config{
 		Cmd:          s.cmd,
 		Entrypoint:   s.entrypoint,
+        Env:          s.env,
 		Hostname:     containerID[:16],
 		WorkingDir:   s.workingDir,
 		Volumes:      s.volumes,


### PR DESCRIPTION
main.go
```
package main

import (
	"fmt"
	"os"
)

func main() {
	fmt.Println(os.Getenv("MY_ENV"))
}
```

wercker.yml
```
build:
  box:
    id: golang
  steps:
    - script:
        name: build
        code: |
          go build -o /pipeline/source/main

deploy:
  box:
    id: golang
  steps:
    - internal/docker-scratch-push:
        tag: test001
        port: "5000"
        repository: localhost
        cmd: /main
        env: "MY_ENV=my-env"
```


```
$ wercker --debug build --no-remove --direct-mount
$ wercker --debug deploy --docker-local
$ docker run localhost:test001 /main
```

expect
```
$ docker run localhost:test001 /main
my-env
```

actual
```
$ docker run localhost:test001 /main

```