### PR TITLE
add memory constraints for boxes and services

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 - Add env option to docker-scratch-push (#295)
 - Allow relative paths for file:// targets in dev mode (#296)
+- Better control limiting memory on run containers, when using
+  services gives the services a 25% of the total memoery to split
+  amongst themselves (#299)
 
 ## v1.0.758 (2017-01-27)
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -41,6 +41,12 @@ var (
 		cli.StringSliceFlag{Name: "docker-dns", Value: &cli.StringSlice{}, Usage: "Docker DNS server.", EnvVar: "DOCKER_DNS", Hidden: true},
 		cli.BoolFlag{Name: "docker-local", Usage: "Don't interact with remote repositories"},
 		cli.StringFlag{Name: "checkpoint", Value: "", Usage: "Skip to the next step after a recent build checkpoint."},
+		cli.IntFlag{Name: "docker-cpu-period", Usage: "Set docker CPU period NOTIMPLEMENTED", Hidden: true},
+		cli.IntFlag{Name: "docker-cpu-quota", Usage: "Set docker CPU quota NOTIMPLEMENTED", Hidden: true},
+		cli.IntFlag{Name: "docker-memory", Usage: "Set docker user memory limit in MB", Hidden: true},
+		cli.IntFlag{Name: "docker-memory-swap", Usage: "Set docker user memory swap limit in MB", Hidden: true},
+		cli.IntFlag{Name: "docker-memory-reservation", Usage: "Set docker user memory soft limit in MB NOTIMPLEMENTED", Hidden: true},
+		cli.IntFlag{Name: "docker-kernel-memory", Usage: "Set docker kernel memory limit in MB NOTIMPLEMENTED", Hidden: true},
 	}
 
 	// These flags control where we store local files

--- a/docker/options.go
+++ b/docker/options.go
@@ -25,11 +25,17 @@ import (
 
 // DockerOptions for our docker client
 type Options struct {
-	Host      string
-	TLSVerify string
-	CertPath  string
-	DNS       []string
-	Local     bool
+	Host              string
+	TLSVerify         string
+	CertPath          string
+	DNS               []string
+	Local             bool
+	CPUPeriod         int64
+	CPUQuota          int64
+	Memory            int64
+	MemoryReservation int64
+	MemorySwap        int64
+	KernelMemory      int64
 }
 
 func guessAndUpdateDockerOptions(opts *Options, e *util.Environment) {
@@ -107,13 +113,25 @@ func NewOptions(c util.Settings, e *util.Environment) (*Options, error) {
 	dockerCertPath, _ := c.String("docker-cert-path")
 	dockerDNS, _ := c.StringSlice("docker-dns")
 	dockerLocal, _ := c.Bool("docker-local")
+	dockerCPUPeriod, _ := c.Int("docker-cpu-period")
+	dockerCPUQuota, _ := c.Int("docker-cpu-quota")
+	dockerMemory, _ := c.Int("docker-memory")
+	dockerMemoryReservation, _ := c.Int("docker-memory-reservation")
+	dockerMemorySwap, _ := c.Int("docker-memory-swap")
+	dockerKernelMemory, _ := c.Int("docker-kernel-memory")
 
 	speculativeOptions := &Options{
-		Host:      dockerHost,
-		TLSVerify: dockerTLSVerify,
-		CertPath:  dockerCertPath,
-		DNS:       dockerDNS,
-		Local:     dockerLocal,
+		Host:              dockerHost,
+		TLSVerify:         dockerTLSVerify,
+		CertPath:          dockerCertPath,
+		DNS:               dockerDNS,
+		Local:             dockerLocal,
+		CPUPeriod:         int64(dockerCPUPeriod),
+		CPUQuota:          int64(dockerCPUQuota),
+		Memory:            int64(dockerMemory) * 1024 * 1024,
+		MemoryReservation: int64(dockerMemoryReservation) * 1024 * 1024,
+		MemorySwap:        int64(dockerMemorySwap) * 1024 * 1024,
+		KernelMemory:      int64(dockerKernelMemory) * 1024 * 1024,
 	}
 
 	// We're going to try out a few settings and set DockerHost if


### PR DESCRIPTION
better control limiting memory on run containers, when using services gives the services a 25% of the total memoery to split amongst themselves