### PR TITLE
automatically detect bash or sh

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@
   amongst themselves, defaults to no limits (#299)
 - Automatically detect bash or sh for containers by default,
   defaulting to bash if it is there (#301)
+- Fix a small bug when doing local deploys and using a working-dir other
+  than .wercker (#301)
 
 ## v1.0.758 (2017-01-27)
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,8 +3,10 @@
 - Add env option to docker-scratch-push (#295)
 - Allow relative paths for file:// targets in dev mode (#296)
 - Better control limiting memory on run containers, when using
-  services gives the services a 25% of the total memoery to split
-  amongst themselves (#299)
+  services gives the services a 25% of the total memory to split
+  amongst themselves, defaults to no limits (#299)
+- Automatically detect bash or sh for containers by default,
+  defaulting to bash if it is there (#301)
 
 ## v1.0.758 (2017-01-27)
 

--- a/core/options.go
+++ b/core/options.go
@@ -761,10 +761,11 @@ func NewDeployOptions(c util.Settings, e *util.Environment) (*PipelineOptions, e
 	// default to last build output if none defined
 	target, _ := c.String("target")
 	if target == "" {
-		found, err := util.Exists("./.wercker/latest/output")
+		latestPath := pipelineOpts.WorkingPath("latest", "output")
+		found, err := util.Exists(latestPath)
 		if err == nil && found {
 			util.RootLogger().Println("No target specified, using recent build output.")
-			pipelineOpts.ProjectPath, _ = filepath.Abs("./.wercker/latest/output")
+			pipelineOpts.ProjectPath, _ = filepath.Abs(latestPath)
 		}
 	}
 

--- a/docker/box.go
+++ b/docker/box.go
@@ -87,7 +87,7 @@ func NewDockerBox(boxConfig *core.BoxConfig, options *core.PipelineOptions, dock
 
 	cmd := boxConfig.Cmd
 	if cmd == "" {
-		cmd = "/bin/bash"
+		cmd = DefaultDockerCommand
 	}
 
 	entrypoint := boxConfig.Entrypoint

--- a/docker/box.go
+++ b/docker/box.go
@@ -331,7 +331,10 @@ func (b *DockerBox) RecoverInteractive(cwd string, pipeline core.Pipeline, step 
 	env = append(env, pipeline.Env().Hidden.Export()...)
 	env = append(env, step.Env().Export()...)
 	env = append(env, fmt.Sprintf("cd %s", cwd))
-	cmd, _ := shlex.Split(b.cmd)
+	cmd, err := shlex.Split(b.cmd)
+	if err != nil {
+		return err
+	}
 	return client.AttachInteractive(container.ID, cmd, env)
 }
 

--- a/docker/box.go
+++ b/docker/box.go
@@ -331,7 +331,7 @@ func (b *DockerBox) RecoverInteractive(cwd string, pipeline core.Pipeline, step 
 	env = append(env, pipeline.Env().Hidden.Export()...)
 	env = append(env, step.Env().Export()...)
 	env = append(env, fmt.Sprintf("cd %s", cwd))
-	cmd := []string{b.cmd}
+	cmd, _ := shlex.Split(b.cmd)
 	return client.AttachInteractive(container.ID, cmd, env)
 }
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -45,6 +45,8 @@ import (
 	"golang.org/x/net/context"
 )
 
+var DefaultDockerCommand = `/bin/sh -c "if [ -e /bin/bash ]; then /bin/bash; else /bin/sh; fi"`
+
 func RequireDockerEndpoint(options *Options) error {
 	client, err := NewDockerClient(options)
 	if err != nil {
@@ -124,6 +126,7 @@ func NewDockerClient(options *Options) (*DockerClient, error) {
 // RunAndAttach gives us a raw connection to a newly run container
 func (c *DockerClient) RunAndAttach(name string) error {
 	hostConfig := &docker.HostConfig{}
+	cmd, _ := shlex.Split(DefaultDockerCommand)
 	container, err := c.CreateContainer(
 		docker.CreateContainerOptions{
 			Name: uuid.NewRandom().String(),
@@ -131,7 +134,7 @@ func (c *DockerClient) RunAndAttach(name string) error {
 				Image:        name,
 				Tty:          true,
 				OpenStdin:    true,
-				Cmd:          []string{"/bin/bash"},
+				Cmd:          cmd,
 				AttachStdin:  true,
 				AttachStdout: true,
 				AttachStderr: true,

--- a/docker/shellstep.go
+++ b/docker/shellstep.go
@@ -78,7 +78,8 @@ func (s *ShellStep) InitEnv(env *util.Environment) {
 			s.Cmd = parts
 		}
 	} else {
-		s.Cmd = []string{"/bin/bash"}
+		cmd, _ := shlex.Split(DefaultDockerCommand)
+		s.Cmd = cmd
 	}
 	s.env = env
 }

--- a/test-all.sh
+++ b/test-all.sh
@@ -95,6 +95,16 @@ runTests() {
   basicTest "after steps" build --pipeline build_true "$testsDir/after-steps-fail" --docker-local || return 1
   basicTest "relative symlinks" build "$testsDir/relative-symlinks" --docker-local || return 1
 
+  # test different shells
+  basicTest "bash_or_sh alpine" build --pipeline test-alpine --docker-local "$testsDir/bash_or_sh" || return 1
+  basicTest "bash_or_sh busybox" build --pipeline test-busybox --docker-local "$testsDir/bash_or_sh" || return 1
+  basicTest "bash_or_sh ubuntu" build --pipeline test-ubuntu --docker-local "$testsDir/bash_or_sh" || return 1
+  # test for a specific bug around failures
+  basicTestFail "bash_or_sh alpine failures" --no-colors  build --pipeline test-alpine-fail --docker-local "$testsDir/bash_or_sh" || return 1
+  grep -q "second fail" "${workingDir}/bash_or_sh alpine failures.log" && echo "^^ failed" && return 1
+  basicTestFail "bash_or_sh ubuntu failures" --no-colors  build --pipeline test-ubuntu-fail --docker-local "$testsDir/bash_or_sh" || return 1
+  grep -q "second fail" "${workingDir}/bash_or_sh ubuntu failures.log" && echo "^^ failed" && return 1
+
   # this one will fail but we'll grep the log for After-step passed: test
   basicTestFail "after steps fail" --no-colors build --pipeline build_fail "$testsDir/after-steps-fail" --docker-local || return 1
   grep -q "After-step passed: test" "${workingDir}/after steps fail.log" || return 1

--- a/tests/projects/bash_or_sh/wercker.yml
+++ b/tests/projects/bash_or_sh/wercker.yml
@@ -1,0 +1,94 @@
+test-alpine-manual:
+  box:
+    id: alpine
+    cmd: /bin/sh -c "if [ -e /bin/bash ]; then /bin/bash; else /bin/sh; fi"
+  steps:
+    - script:
+        code: |
+          [ $0 == "/bin/sh" ] && echo "running sh" || exit 1
+    - script:
+        name: first fail
+        code: |
+          echo "first fail"
+          false
+    - script:
+        name: second fail
+        code: |
+          echo "second fail"
+          false
+
+
+test-ubuntu-manual:
+  box:
+    id: ubuntu
+    cmd: /bin/sh -c "if [ -e /bin/bash ]; then /bin/bash; else /bin/sh; fi"
+  steps:
+    - script:
+        code: |
+          [ $0 == "/bin/bash" ] && echo "running bash" || exit 1
+    - script:
+        name: first fail
+        code: |
+          echo "first fail"
+          false
+    - script:
+        name: second fail
+        code: |
+          echo "second fail"
+          false
+
+
+test-alpine:
+  box: alpine
+  steps:
+    - script:
+        code: |
+          [ $0 == "/bin/sh" ] && echo "running sh" || exit 1
+
+test-busybox:
+  box: busybox
+  steps:
+    - script:
+        code: |
+          [ $0 == "/bin/sh" ] && echo "running sh" || exit 1
+
+test-ubuntu:
+  box: ubuntu
+  steps:
+    - script:
+        code: |
+          [ $0 == "/bin/bash" ] && echo "running bash" || exit 1
+
+test-alpine-fail:
+  box: alpine
+  steps:
+    - script:
+        code: |
+          [ $0 == "/bin/sh" ] && echo "running sh" || exit 1
+    - script:
+        name: first fail
+        code: |
+          echo "first fail"
+          false
+    - script:
+        name: second fail
+        code: |
+          echo "second fail"
+          false
+
+test-ubuntu-fail:
+  box: ubuntu
+  steps:
+    - script:
+        code: |
+          [ $0 == "/bin/bash" ] && echo "running bash" || exit 1
+    - script:
+        name: first fail
+        code: |
+          echo "first fail"
+          false
+    - script:
+        name: second fail
+        code: |
+          echo "second fail"
+          false

--- a/tests/projects/scratch-n-push/wercker.yml
+++ b/tests/projects/scratch-n-push/wercker.yml
@@ -10,5 +10,5 @@ build:
         username: $DOCKER_USER
         password: $DOCKER_PASSWORD
         registry: https://quay.io
-        tag: $WERCKER_GIT_BRANCH-$WERCKER_GIT_COMMIT
+        tag: uniqueTagFromTest
         repository: quay.io/wercker/scratch-n-push


### PR DESCRIPTION
# wat 

- Automatically detect bash or sh for containers by default,
defaulting to bash if it is there (#301)
- Fix a small bug when doing local deploys and using a working-dir other
 than .wercker (#301)

# y 

alpine containers use /bin/sh, many others use /bin/bash, our default has always been /bin/bash, but this made many containers fail until a command was set explicitly, this removes that need

re deploy bug, local deploy auto-path-lookup-magic was using a hardcoded .wrcker instead of looking at working-dir