### PR TITLE
fix parameter not to be string in canary

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -224,7 +224,7 @@ canary:
     - script:
         name: Create canary deploy
         code: |
-          data="{\"sentcliBranch\": \"canary-$WERCKER_GIT_BRANCH\", \"sentcliCommit\": \"$WERCKER_GIT_COMMIT\", \"users\": [ \"$CANARY_USERS\" ], \"percentage\": $CANARY_PERCENTAGE, \"total\": $CANARY_TOTAL, \"fastFailThreshold\": \"$CANARY_FAST_FAIL\"}"
+          data="{\"sentcliBranch\": \"canary-$WERCKER_GIT_BRANCH\", \"sentcliCommit\": \"$WERCKER_GIT_COMMIT\", \"users\": [ \"$CANARY_USERS\" ], \"percentage\": $CANARY_PERCENTAGE, \"total\": $CANARY_TOTAL, \"fastFailThreshold\": $CANARY_FAST_FAIL}"
           echo $data
           curl -X POST --data "$data" "$CANARY_ENDPOINT"
           if [ $? -ne 0 ]; then


### PR DESCRIPTION
#304 made it fast fail a string, when its actually a number. this fixes that
