### PR TITLE
Keep the order when collecting pass-through vars

### DIFF
--- a/util/environment.go
+++ b/util/environment.go
@@ -20,6 +20,11 @@ import (
 	"strings"
 )
 
+var (
+	protected = "XXX_"
+	public    = "X_"
+)
+
 // Environment represents a shell environment and is implemented as something
 // like an OrderedMap
 type Environment struct {
@@ -103,28 +108,25 @@ var mirroredEnv = [...]string{
 
 // Collect passthru variables from the project
 func (e *Environment) GetPassthru() (env *Environment) {
-	a := [][]string{}
-	for key, value := range e.Map {
-		if strings.HasPrefix(key, "X_") {
-			a = append(a, []string{strings.TrimPrefix(key, "X_"), value})
-		}
-	}
-	env = &Environment{}
-	env.Update(a)
-	return env
+	return e.passthru(public)
 }
 
 // Collect the hidden passthru variables
 func (e *Environment) GetHiddenPassthru() (env *Environment) {
+	return e.passthru(protected)
+}
+
+func (e *Environment) passthru(prefix string) (env *Environment) {
 	a := [][]string{}
-	for key, value := range e.Map {
-		if strings.HasPrefix(key, "XXX_") {
-			a = append(a, []string{strings.TrimPrefix(key, "XXX_"), value})
+	for _, key := range e.Order {
+		if strings.HasPrefix(key, prefix) {
+			a = append(a, []string{strings.TrimPrefix(key, prefix), e.Map[key]})
 		}
 	}
 	env = &Environment{}
 	env.Update(a)
 	return env
+
 }
 
 func (e *Environment) GetMirror() [][]string {

--- a/util/environment_test.go
+++ b/util/environment_test.go
@@ -39,6 +39,19 @@ func (s *EnvironmentSuite) TestPassthru() {
 	s.Equal(1, len(env.GetHiddenPassthru().Ordered()))
 }
 
+func (s *EnvironmentSuite) TestPassthruKeepsOrder() {
+	env := NewEnvironment("X_fake1=val1", "X_fake2=val2", "X_fake3=$fake2")
+	actual := env.GetPassthru()
+	expected := []string{"fake1", "fake2", "fake3"}
+	s.Equal(expected, actual.Order)
+}
+func (s *EnvironmentSuite) TestPassthruHiddenKeepsOrder() {
+	env := NewEnvironment("XXX_fake1=val1", "XXX_fake2=val2", "XXX_fake3=$fake2")
+	actual := env.GetHiddenPassthru()
+	expected := []string{"fake1", "fake2", "fake3"}
+	s.Equal(expected, actual.Order)
+}
+
 func (s *EnvironmentSuite) TestInterpolate() {
 	env := NewEnvironment("PUBLIC=foo", "X_PRIVATE=zed", "XXX_OTHER=otter")
 	env.Update(env.GetPassthru().Ordered())


### PR DESCRIPTION
The GetPassthru and GetHiddenPassthru functions don't keep the order of
the Envs, that is because they range over the Environment.Map. The fix
is to range over the Environment.Order.
In addition to that we added a small refactor to put the logic of the
collection mechanism in a single function so we can avoid code
duplication.