### PR TITLE
fix: Handle quoted environment variable values in environment file

### DIFF
--- a/tests/environment-test-load-file.env
+++ b/tests/environment-test-load-file.env
@@ -11,3 +11,13 @@ F=6
 
 # Extra spaces after value
 G=7
+
+
+# Test quotes, expansion and empty vals
+H='8'
+I="9"
+J="Hello \"quotes\""
+K=
+L="\n"
+M=\"
+N="

--- a/util/environment.go
+++ b/util/environment.go
@@ -184,8 +184,30 @@ func (e *Environment) LoadFile(f string) error {
 		if e.Get(key) != "" {
 			continue
 		}
+
+		val = trim(val)
+
 		e.Add(key, val)
 	}
 
 	return nil
+}
+
+func trim(s string) string {
+	s = strings.TrimSpace(s)
+
+	if len(s) > 1 {
+		f := string(s[0:1])
+		l := string(s[len(s)-1:])
+		if f == l && strings.ContainsAny(f, `"'`) {
+			// strip surrounding quotes
+			s = string(s[1 : len(s)-1])
+
+			// now expand escaped double quotes and newlines
+			s = strings.Replace(s, `\"`, `"`, -1)
+			s = strings.Replace(s, `\n`, "\n", -1)
+		}
+	}
+
+	return s
 }

--- a/util/environment_test.go
+++ b/util/environment_test.go
@@ -93,10 +93,17 @@ func (s *EnvironmentSuite) TestLoadFile() {
 		[]string{"E", "5"},
 		[]string{"F", "6"},
 		[]string{"G", "7"},
+		[]string{"H", "8"},
+		[]string{"I", "9"},
+		[]string{"J", "Hello \"quotes\""},
+		[]string{"K", ""},
+		[]string{"L", "\n"},
+		[]string{"M", `\"`},
+		[]string{"N", `"`},
 	}
 	env.LoadFile("../tests/environment-test-load-file.env")
-	s.Equal(8, len(env.Ordered()), "Should only load 8 valid lines.")
+	s.Equal(15, len(env.Ordered()), "Should only load 8 valid lines.")
 	s.Equal("foo", env.Get("PUBLIC"), "LoadFile should ignore keys already set in env.")
 	s.Equal(expected, env.Ordered(), "LoadFile should maintain order.")
-	s.Equal([]string{"PUBLIC", "A", "B", "C", "D", "E", "F", "G"}, env.Order, "LoadFile should maintain ordered keys.")
+	s.Equal([]string{"PUBLIC", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N"}, env.Order, "LoadFile should maintain ordered keys.")
 }


### PR DESCRIPTION
Missed the fact that godotenv handled quotes and that wercker environment files are quoted. This fixes that.