### PR TITLE
Some nice additions to the way we do the docker push and test

### DIFF
--- a/docker/docker_push_test.go
+++ b/docker/docker_push_test.go
@@ -1,0 +1,50 @@
+package dockerlocal
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/wercker/wercker/core"
+	"github.com/wercker/wercker/util"
+)
+
+type PushSuite struct {
+	*util.TestSuite
+}
+
+func TestPushSuite(t *testing.T) {
+	suiteTester := &PushSuite{&util.TestSuite{}}
+	suite.Run(t, suiteTester)
+}
+
+//TestEmptyPush tests if you juse did something like this
+// - internal/docker-push
+// it should fill in a tag of the git branch and commit
+// check to see if its pushing up to the right registry or not
+func (s *PushSuite) TestEmptyPush() {
+	config := &core.StepConfig{
+		ID:   "internal/docker-push",
+		Data: map[string]string{},
+	}
+	u, _ := url.Parse("https://container-reg.oracle.com")
+	options := &core.PipelineOptions{
+		GitOptions: &core.GitOptions{
+			GitBranch: "master",
+			GitCommit: "s4k2r0d6a9b",
+		},
+		ApplicationID:            "1000001",
+		ApplicationName:          "myproject",
+		ApplicationOwnerName:     "wercker",
+		WerckerContainerRegistry: u,
+		GlobalOptions: &core.GlobalOptions{
+			AuthToken: "su69persec420uret0k3n",
+		},
+	}
+	step, _ := NewDockerPushStep(config, options, nil)
+	step.InitEnv(nil)
+	repositoryName := step.authenticator.Repository(step.repository)
+	s.Equal("container-reg.oracle.com/wercker/myproject", repositoryName)
+	tags := step.buildTags()
+	s.Equal([]string{"latest", "master-s4k2r0d6a9b"}, tags)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -982,10 +982,10 @@
 			"revisionTime": "2016-03-30T20:38:51Z"
 		},
 		{
-			"checksumSHA1": "yjPvaNfH2PgvP+O8d9Ng5lljNc8=",
+			"checksumSHA1": "SiSe0HkCBCW6vKjZuSkJpvWgOsY=",
 			"path": "github.com/wercker/docker-check-access",
-			"revision": "506de4f171b786ade70ae06badf6bffe7f48c123",
-			"revisionTime": "2017-02-28T23:00:53Z",
+			"revision": "f23b9e18ae9fbcbb80e9cea7ee7eaf8ccb209ca9",
+			"revisionTime": "2017-07-06T22:56:06Z",
 			"version": "master",
 			"versionExact": "master"
 		},


### PR DESCRIPTION
- Updates the the docker-check-access library (there was a bug fix that fixed a panic when using `.Repository()` 
- Adds a tag for branch-commit for an internal push