### PR TITLE
Preserve timestamp when copying source to container

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 - Update dependencies, as a result of `Sirupsen/logrus` -> `sirupsen/logrus` (#333)
 - Add a Docker subcommand (#335)
 - Ensure repository names are always lowercase (#338)
+- Preservce timestamps when copying source and cache into container (#340)
 
 ## v1.0.965 (2017-08-23)
 

--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -203,9 +203,9 @@ func (p *BasePipeline) SetupGuest(sessionCtx context.Context, sess *Session) err
 			fmt.Sprintf(`rm -rf "%s"`, filepath.Dir(p.options.BasePath())),
 			fmt.Sprintf(`mkdir -p "%s"`, filepath.Dir(p.options.BasePath())),
 			// Copy the source from the mounted directory to the base path
-			fmt.Sprintf(`cp -r "%s" "%s"`, p.options.MntPath("source"), p.options.BasePath()),
+			fmt.Sprintf(`cp -r -p "%s" "%s"`, p.options.MntPath("source"), p.options.BasePath()),
 			// Copy the cache from the mounted directory to the pipeline dir
-			fmt.Sprintf(`cp -r "%s" "%s"`, p.options.MntPath("cache"), p.options.GuestPath("cache")),
+			fmt.Sprintf(`cp -r -p "%s" "%s"`, p.options.MntPath("cache"), p.options.GuestPath("cache")),
 		)
 	}
 


### PR DESCRIPTION
This should preserve the timestamp of the git repository or the local files. A user was having a specific issue which had to do with golang rebuilding every package every time. Even though the user had every file in the cache (`go install` uses timestamps to determine if a package needs to be rebuild)