### PR TITLE
Interpolate the box name when starting service

### DIFF
--- a/docker/service.go
+++ b/docker/service.go
@@ -185,7 +185,7 @@ func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment, lin
 	}
 
 	conf := &docker.Config{
-		Image:           b.Name,
+		Image:           env.Interpolate(b.Name),
 		Cmd:             cmd,
 		Env:             myEnv,
 		ExposedPorts:    exposedPorts(b.config.Ports),

--- a/tests/projects/interpolate-service-name/wercker.yml
+++ b/tests/projects/interpolate-service-name/wercker.yml
@@ -1,0 +1,10 @@
+build:
+  box: alpine:3.6
+  services:
+    - name: service-box
+      id: redis
+      tag: $AN_ENV_VAR
+  steps:
+    - script:
+      name: prepare /bin
+      code: echo "testing"


### PR DESCRIPTION
We'd like to be able to tag images with their commit SHA, push to a
container registry, pull down this same image in a subsequent
pipeline and run it as a service. In order to do that, we need the `tag`
field of the service configuration to be interpolated. 

Are there any issues with this implementation?

As far as I can tell it should have no negative impact.