### PR TITLE
Add support for Gradle and Maven based Java projects in wercker detect.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -549,6 +549,14 @@ outer:
 		case filepath.Ext(f.Name()) == ".go":
 			detected = "golang"
 			break outer
+
+        case f.Name() == "pom.xml":
+            detected = "java-maven"
+            break outer
+
+        case filepath.Ext(f.Name()) == ".gradle", f.Name() == "gradlew":
+            detected = "java-gradle"
+            break outer
 		}
 	}
 	if detected == "" {


### PR DESCRIPTION
Fixes wercker/backlog#1575 and fixes wercker/backlog#1576.  wercker detect now detects the project as java-maven based on presence of pom.xml and java-gradle based on presence of *.gradle, or gradlew.