### PR TITLE
Fixes #357. Check for errors after starting box container

### DIFF
--- a/docker/box.go
+++ b/docker/box.go
@@ -443,6 +443,11 @@ func (b *DockerBox) Run(ctx context.Context, env *util.Environment) (*docker.Con
 	}
 
 	client.StartContainer(container.ID, hostConfig)
+
+	if err != nil {
+		return nil, err
+	}
+
 	b.container = container
 	return container, nil
 }

--- a/docker/box.go
+++ b/docker/box.go
@@ -442,7 +442,7 @@ func (b *DockerBox) Run(ctx context.Context, env *util.Environment) (*docker.Con
 		return nil, err
 	}
 
-	client.StartContainer(container.ID, hostConfig)
+	err = client.StartContainer(container.ID, hostConfig)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes [issue-357](https://github.com/wercker/wercker/issues/357) - check for status of starting the box container before progressing further..
[Wercker build run url](https://app.wercker.com/wercker/wercker/runs/build/5a9e95c7dfd4d200016ed75b)