### PR TITLE
Fixes #357 - Check for errors in starting box container

### DIFF
--- a/docker/box.go
+++ b/docker/box.go
@@ -438,11 +438,12 @@ func (b *DockerBox) Run(ctx context.Context, env *util.Environment) (*docker.Con
 
 	b.logger.Debugln("Docker Container:", container.ID)
 
+	err = client.StartContainer(container.ID, hostConfig)
+
 	if err != nil {
 		return nil, err
 	}
 
-	client.StartContainer(container.ID, hostConfig)
 	b.container = container
 	return container, nil
 }


### PR DESCRIPTION
Fixes [357](https://github.com/wercker/wercker/issues/357) - Check for error after starting box. There was an extraneous check on error being null, moved the code to start container above it and captured the error
[Wercker Build run url](https://app.wercker.com/wercker/wercker/runs/build/5a9e9a5f88122900019f1ca9)