### PR TITLE
Fix for #1650:  In session.go, SendChecked sometimes hangs #1650 

### DIFF
--- a/core/session.go
+++ b/core/session.go
@@ -199,19 +199,26 @@ func smartSplitLines(line, sentinel string) []string {
 		possibleSentinel := splitLines[len(splitLines)-2]
 		// And we expect a newline at the end
 		possibleSentinel = fmt.Sprintf("%s\n", possibleSentinel)
-		foundExit, _ := checkLine(possibleSentinel, sentinel)
-		// If we found the exit code, make sure it gets read as a separate line
-		if foundExit {
+
+		// does this string contain the sentinel?
+		sentPos := strings.Index(possibleSentinel, sentinel)
+
+		// If we found the sentinel, make sure it gets read as a separate line to anything that preceded it
+		if sentPos >= 0 {
 			// If we weren't the only line to begin with, add the rest
 			if len(splitLines) > 2 {
 				otherLines := strings.Join(splitLines[:len(splitLines)-2], "\n")
 				otherLines = fmt.Sprintf("%s\n", otherLines)
 				lines = append(lines, otherLines)
 			}
-			// Add the line we split off
-			lines = append(lines, possibleSentinel)
+			if sentPos > 0 {
+				// Add the characters before the sentinel on its own line
+				lines = append(lines, possibleSentinel[0:sentPos])
+			}
+			// add the sentinel (and whatever follows) on its own line
+			lines = append(lines, possibleSentinel[sentPos:])
 		} else {
-			// Otherwise if no exit was found just return the whole thing
+			// Otherwise a sentinel was not found so just return the whole thing
 			lines = append(lines, line)
 		}
 	} else {


### PR DESCRIPTION
See https://github.com/wercker/backlog/issues/1650 for a description of the issue which this PR fixes.

Essentially, this method previously only handled the case where the sentinel at the start of the line.

This fix handles the case (which I have seen intermittently, about 1 in 5 times when running in the CLI) when the sentinel string is appended to some previous output. When this occurs the sentinel string (and any characters that follow it - see note 1 below) are moved to a separate line.

Note 1:  Why do I copy the sentinel string *and any characters that follow it* to a separate line? The reason is that the the sentinel appears to be always followed by a space and an integer, 0 in the cases I have seen.  This is explicitly tested in the `checkLine` function, which is used by the caller to test whether a line returned by this function contains a sentinel.