### PR TITLE
Fix for govendor sync failures on "gopkg.in/fsnotify.v1"

### DIFF
--- a/docker/watchstep.go
+++ b/docker/watchstep.go
@@ -24,13 +24,12 @@ import (
 	"strings"
 	"time"
 
-	// I am going to fix this soon
+	"gopkg.in/fsnotify/fsnotify.v1"
 
 	"github.com/pborman/uuid"
 	"github.com/wercker/wercker/core"
 	"github.com/wercker/wercker/util"
 	"golang.org/x/net/context"
-	fsnotify "gopkg.in/fsnotify/fsnotify.v1"
 )
 
 // test TODO (mh)

--- a/docker/watchstep.go
+++ b/docker/watchstep.go
@@ -24,12 +24,13 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/fsnotify.v1"
+	// I am going to fix this soon
 
 	"github.com/pborman/uuid"
 	"github.com/wercker/wercker/core"
 	"github.com/wercker/wercker/util"
 	"golang.org/x/net/context"
+	fsnotify "gopkg.in/fsnotify/fsnotify.v1"
 )
 
 // test TODO (mh)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2492,10 +2492,10 @@
 			"revisionTime": "2016-03-28T14:24:51Z"
 		},
 		{
-			"checksumSHA1": "x+4kbqqCxPCCspC3ZN7x3WTDWzc=",
-			"path": "gopkg.in/fsnotify.v1",
-			"revision": "30411dbcefb7a1da7e84f75530ad3abe4011b4f8",
-			"revisionTime": "2016-04-12T13:37:56Z"
+			"checksumSHA1": "o48HV7RTuWgAA//aJsiXBdceHSM=",
+			"path": "gopkg.in/fsnotify/fsnotify.v1",
+			"revision": "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9",
+			"revisionTime": "2018-01-10T05:33:47Z"
 		},
 		{
 			"checksumSHA1": "8xrbOd6aYpW382QUHkRv+R7+4hk=",


### PR DESCRIPTION
The wercker CLI build pipeline appears to be broken because of the following error in the "build dependencies" step:
```
Failed for "gopkg.in/fsnotify.v1" (failed to ping remote repo): unrecognized import path "gopkg.in/fsnotify.v1"
```
For example, I added a comment to a file (in order to trigger a build) and got this failure:
https://dev.wercker.com/wercker/wercker/runs/build/5ab5498729bb860001efad11?step=5ab549902069f00001caa073

The cause seems to be an incorrect package name in an import statement. I have fixed this and updated `vendor.json` accordingly. This immediately made the build pass:
https://dev.wercker.com/wercker/wercker/runs/build/5ab54a4929bb860001efad18

I hereby submit this PR for review
