### PR TITLE
Fix #1741 Correct status reporting from docker push by parsing status messages from docker

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 ## unreleased
 
+## v1.0.XXXX(2018-04-XX)
+
+- Fix status reporting for docker push (#371)
+
+
 ## v1.0.1183 (2018-03-29)
 
 - New docker-build step and enhanded docker-push step (#362)

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,6 @@
 ## unreleased
 
-## v1.0.XXXX(2018-04-XX)
-
 - Fix status reporting for docker push (#371)
-
 
 ## v1.0.1183 (2018-03-29)
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -60,7 +60,7 @@ const (
 
 //TODO: The current fsouza/go-dockerclient does not contain structs for status messages emitted
 // from docker in case of push - therefore had to explicitly create these structs for better
-// usablity of code (instead of decofing json to a map). Official docker client should contain
+// usablity of code (instead of unmarshalling json to a map). Official docker client should contain
 // these structs(or equivalents) already and this code should be refactored to use those instead
 // having to maintain our own.
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -16,9 +16,11 @@ package dockerlocal
 
 import (
 	"archive/tar"
+	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -40,6 +42,7 @@ import (
 	"github.com/google/shlex"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pborman/uuid"
+	"github.com/pkg/errors"
 	"github.com/wercker/docker-check-access"
 	"github.com/wercker/wercker/auth"
 	"github.com/wercker/wercker/core"
@@ -52,7 +55,44 @@ const (
 	// so the value can be anything so long as it's not empty.
 	DefaultDockerRegistryUsername = "token"
 	DefaultDockerCommand          = `/bin/sh -c "if [ -e /bin/bash ]; then /bin/bash; else /bin/sh; fi"`
+	NoPushConfirmationInStatus    = "Docker push failed to complete.Please check logs for any error condition"
 )
+
+//TODO: The current fsouza/go-dockerclient does not contain structs for status messages emitted
+// from docker in case of push - therefore had to explicitly create these structs for better
+// usablity of code (instead of decofing json to a map). Official docker client should contain
+// these structs(or equivalents) already and this code should be refactored to use those instead
+// having to maintain our own.
+
+//PushStatusAux : The "aux" component of status message
+type PushStatusAux struct {
+	Tag    string `json:"Tag,omitempty"`
+	Digest string `json:"Digest,omitempty"`
+	Size   int64  `json:"Size,omitempty"`
+}
+
+//PushStatusProgressDetail : The "progressDetail" component of status message
+type PushStatusProgressDetail struct {
+	Current int64 `json:"current,omitempty"`
+	Total   int64 `json:"total,omitempty"`
+}
+
+//PushStatusErrorDetail : The "errorDetail" component of status message
+type PushStatusErrorDetail struct {
+	Message string `json:"message,omitempty"`
+	Code    string `json:"code,omitempty"`
+}
+
+//PushStatus : Status message from Push message
+type PushStatus struct {
+	Status         string                    `json:"status,omitempty"`
+	ID             string                    `json:"id,omitempty"`
+	Progress       string                    `json:"progress,omitempty"`
+	Error          string                    `json:"error,omitempty"`
+	Aux            *PushStatusAux            `json:"aux,omitempty"`
+	ProgressDetail *PushStatusProgressDetail `json:"progressDetail,omitempty"`
+	ErrorDetail    *PushStatusErrorDetail    `json:"errorDetail,omitempty"`
+}
 
 func RequireDockerEndpoint(options *Options) error {
 	client, err := NewDockerClient(options)
@@ -994,7 +1034,6 @@ func (s *DockerPushStep) tagAndPush(imageID string, e *core.NormalizedEmitter, c
 	r, w := io.Pipe()
 	// emitStatusses in a different go routine
 	go EmitStatus(e, r, s.options)
-	defer w.Close()
 	for _, tag := range s.tags {
 		tagOpts := docker.TagImageOptions{
 			Repo:  s.repository,
@@ -1007,12 +1046,20 @@ func (s *DockerPushStep) tagAndPush(imageID string, e *core.NormalizedEmitter, c
 			s.logger.Errorln("Failed to push:", err)
 			return 1, err
 		}
+		inactivityDuration := 5 * time.Minute
+		buf := new(bytes.Buffer)
+		mw := io.MultiWriter(w, buf)
 		pushOpts := docker.PushImageOptions{
-			Name:          s.repository,
-			OutputStream:  w,
-			RawJSONStream: true,
-			Tag:           tag,
+			Name:              s.repository,
+			OutputStream:      mw,
+			RawJSONStream:     true,
+			Tag:               tag,
+			InactivityTimeout: inactivityDuration,
 		}
+		if s.dockerOptions.CleanupImage {
+			defer cleanupImage(s.logger, client, s.repository, tag)
+		}
+		defer w.Close()
 		if !s.dockerOptions.Local {
 			auth := docker.AuthConfiguration{
 				Username: s.authenticator.Username(),
@@ -1024,11 +1071,36 @@ func (s *DockerPushStep) tagAndPush(imageID string, e *core.NormalizedEmitter, c
 				s.logger.Errorln("Failed to push:", err)
 				return 1, err
 			}
-			s.logger.Println("Pushed container:", s.repository, s.tags)
-
-			if s.dockerOptions.CleanupImage {
-				defer cleanupImage(s.logger, client, s.repository, tag)
+			// Covert status messages in stream {...} {...} to a proper json array [{...},{...},...]
+			statusJSON := strings.Join([]string{"[", strings.TrimSuffix(strings.Replace(buf.String(), "\n", ",", -1), ","), "]"}, "")
+			statusMessages := make([]PushStatus, 0)
+			err = json.Unmarshal(([]byte)(statusJSON), &statusMessages)
+			if err != nil {
+				s.logger.Errorln("Failed to parse status outputs from docker push:", err)
+				return 1, err
 			}
+			isContainerPushed := false
+			for _, statusMessage := range statusMessages {
+				if len(strings.TrimSpace(statusMessage.Error)) != 0 {
+					errorMessageToDisplay := statusMessage.Error
+					if statusMessage.ErrorDetail != nil {
+						jsonMessage, _ := json.Marshal(statusMessage.ErrorDetail)
+						errorMessageToDisplay = string(jsonMessage)
+					}
+					s.logger.Errorln("Failed to push:", errorMessageToDisplay)
+					return 1, errors.New(errorMessageToDisplay)
+				}
+				if statusMessage.Aux != nil && statusMessage.Aux.Tag == tag {
+					s.logger.Println("Pushed container:", s.repository, tag, ",Digest:", statusMessage.Aux.Digest)
+					isContainerPushed = true
+				}
+
+			}
+			if !isContainerPushed {
+				s.logger.Errorln("Failed to push tag:", tag, "Please check log messages")
+				return 1, errors.New(NoPushConfirmationInStatus)
+			}
+
 		}
 	}
 	return 0, nil

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1034,6 +1034,7 @@ func (s *DockerPushStep) tagAndPush(imageID string, e *core.NormalizedEmitter, c
 	r, w := io.Pipe()
 	// emitStatusses in a different go routine
 	go EmitStatus(e, r, s.options)
+	defer w.Close()
 	for _, tag := range s.tags {
 		tagOpts := docker.TagImageOptions{
 			Repo:  s.repository,
@@ -1059,7 +1060,6 @@ func (s *DockerPushStep) tagAndPush(imageID string, e *core.NormalizedEmitter, c
 		if s.dockerOptions.CleanupImage {
 			defer cleanupImage(s.logger, client, s.repository, tag)
 		}
-		defer w.Close()
 		if !s.dockerOptions.Local {
 			auth := docker.AuthConfiguration{
 				Username: s.authenticator.Username(),

--- a/docker/docker_push_test.go
+++ b/docker/docker_push_test.go
@@ -1,13 +1,27 @@
 package dockerlocal
 
 import (
+	"encoding/json"
 	"net/url"
 	"testing"
 
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/suite"
+	"github.com/wercker/docker-check-access"
 	"github.com/wercker/wercker/auth"
 	"github.com/wercker/wercker/core"
 	"github.com/wercker/wercker/util"
+)
+
+const (
+	RepoUnauthorized         = "fail_me/unauthorized"
+	ErrorMessageUnauthorized = "unauthorized: incorrect username or password"
+	RepoUnconfirmedPush      = "fail_me/unconfirmed"
+	ErrorMessageUnconfirmed  = NoPushConfirmationInStatus
+	RepoSuccessful           = "pass_me/successful"
+	RepoSuccessfulImageSHA   = "9987d147c777f2fff2ec17d557304b20da65bc9e270f945623ab04de59ca4f2c"
+	RepoSuccessfulImageSize  = 121
+	RepoSuccessfulImageTag   = "stage"
 )
 
 type PushSuite struct {
@@ -75,4 +89,101 @@ func (s *PushSuite) TestInferRegistry() {
 		s.Equal(tt.expectedRegistry, opts.Registry, "%q, wants %q", opts.Registry, tt.expectedRegistry)
 		s.Equal(tt.expectedRepository, repo, "%q, wants %q", repo, tt.expectedRepository)
 	}
+
+}
+
+//TestTagAndPushCorretStatusReportingForUnauthorizedFailedPush - Tests a scenario when
+// push will fail due to an unauthorized access to a repo
+func (s *PushSuite) TestTagAndPushCorretStatusReportingForUnauthorizedFailedPush() {
+	stepData := make(map[string]string)
+	stepData["username"] = "user"
+	stepData["password"] = "pass"
+	stepData["repository"] = RepoUnauthorized
+	stepData["registry"] = "https://quay.io"
+	stepData["tag"] = "test"
+
+	exitCode, error := executePushStep(stepData)
+	s.NotEqual(exitCode, 0)
+	s.NotNil(error)
+	s.Contains(error.Error(), ErrorMessageUnauthorized)
+}
+
+//TestTagAndPushCorretStatusReportingForUnconfirmedFailedPush - Tests a scenario when
+// push will not return any failure message as such and also will not be successful!
+func (s *PushSuite) TestTagAndPushCorretStatusReportingForUnconfirmedFailedPush() {
+	stepData := make(map[string]string)
+	stepData["username"] = "user"
+	stepData["password"] = "pass"
+	stepData["repository"] = RepoUnconfirmedPush
+	stepData["registry"] = "https://quay.io"
+	stepData["tag"] = "test"
+
+	exitCode, error := executePushStep(stepData)
+	s.NotEqual(exitCode, 0)
+	s.NotNil(error)
+	s.Contains(error.Error(), ErrorMessageUnconfirmed)
+}
+
+//TestTagAndPushCorretStatusReportingForSuccessfulPush - Tests the scenario when a push is
+// successful and tagAndPush will only return success if the status message from docker will
+// contain digest and tag of pushed container
+func (s *PushSuite) TestTagAndPushCorretStatusReportingForSuccessfulPush() {
+	stepData := make(map[string]string)
+	stepData["username"] = "user"
+	stepData["password"] = "pass"
+	stepData["repository"] = RepoSuccessful
+	stepData["registry"] = "https://quay.io"
+	stepData["tag"] = RepoSuccessfulImageTag
+
+	exitCode, error := executePushStep(stepData)
+	s.Equal(exitCode, 0)
+	s.Nil(error)
+}
+
+//executePushStep - Prepares stepcConfig for docker-push step from input stepData
+// and invokes tagAndPush
+func executePushStep(stepData map[string]string) (int, error) {
+	config := &core.StepConfig{
+		ID:   "internal/docker-push",
+		Data: stepData,
+	}
+	options := &core.PipelineOptions{}
+	step, _ := NewDockerPushStep(config, options, nil)
+	step.configure(&util.Environment{})
+	step.dockerOptions = &Options{}
+	step.authenticator = &auth.DockerAuth{}
+	step.logger = util.NewLogger().WithFields(util.LogFields{
+		"Logger": "Test",
+	})
+	mockEmittor := core.NewNormalizedEmitter()
+	mockDockerClient := &DockerClient{}
+	return step.tagAndPush("test", mockEmittor, mockDockerClient)
+}
+
+//RemoveImage - Mocks DockerClient.TagImage
+func (c *DockerClient) TagImage(name string, opts docker.TagImageOptions) error {
+	return nil
+}
+
+//RemoveImage - Mocks DockerClient.RemoveImage
+func (c *DockerClient) RemoveImage(name string) error {
+	return nil
+}
+
+//PushImage - Mocks DockerClient.PushImage - writes status messages to OutputStream based on repository name
+func (c *DockerClient) PushImage(opts docker.PushImageOptions, auth docker.AuthConfiguration) error {
+	status := &PushStatus{}
+	if opts.Name == RepoUnauthorized {
+		status.Error = ErrorMessageUnauthorized
+		status.ErrorDetail = &PushStatusErrorDetail{Message: ErrorMessageUnauthorized}
+	} else if opts.Name == RepoUnconfirmedPush {
+		status.Status = "Waiting"
+		status.ID = "61c06e07759a"
+		status.ProgressDetail = &PushStatusProgressDetail{}
+	} else if opts.Name == RepoSuccessful {
+		status.Aux = &PushStatusAux{Digest: RepoSuccessfulImageSHA, Size: RepoSuccessfulImageSize, Tag: RepoSuccessfulImageTag}
+	}
+	jsonData, _ := json.Marshal(status)
+	opts.OutputStream.Write(jsonData)
+	return nil
 }

--- a/wercker.yml
+++ b/wercker.yml
@@ -25,7 +25,7 @@ build:
 
     - script:
         name: go test
-        code: govendor test +local
+        code: govendor test -v +local
 
     - script:
         name: clear out the build binaries


### PR DESCRIPTION
**What this PR does / why we need it:**
Fixes [1741](https://github.com/wercker/backlog/issues/1741) 
Both internal/docker-scratch-push and internal-push steps invoke tagAndPush method which further invokes DockerClient.PushImage().In a situation where docker push call will fail due to any reason - one of which being incorrect username/password for the repository, the error is not correctly captured as the REST api call for push to docker daemon immediately returns without any error. The error message is in-fact present in progress status messages from the daemon but we were not looking at those status messages to check whether a push was indeed successful. In case of a successful push, the tag, size and SHA digest of image being pushed is present in status progress messages. In this PR - logic has been changed to not just rely on the error returned by docker client, but look for the actual successful status message in streamed statuses.

**Summary of changes**

1. in docker/docker.go - parse status messages from docker daemon for a push call. Relevant structs were created to correctly marshal the message ( The current client we use does not have structs to marshal these messages directly - We should probably refactor this code once we upgrade to official docker client in [1698](https://github.com/wercker/backlog/issues/1698) - a comment has been added to reflect this.
2. Added unit tests to docker/docker_push_test.go
3. Added -v to govendor test in wercker.yml to be able to see what tests are being run during the build
4. Moved call to cleanupImage a bit up

