### PR TITLE
Fixes #353 - Updates to enable go build and wercker build work with golang 1.10

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+- Fix "go build" and "wercker build" on golang 1.10 (#374)
+
 ## v1.0.1189(2018-04-04)
 
 - Fix status reporting for docker push (#371)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -929,7 +929,7 @@ func executePipeline(cmdCtx context.Context, options *core.PipelineOptions, dock
 	if err != nil {
 		return nil, err
 	}
-	f := &util.Formatter{options.GlobalOptions.ShowColors}
+	f := &util.Formatter{ShowColors: options.GlobalOptions.ShowColors}
 
 	// Set up the runner
 	r, err := NewRunner(cmdCtx, options, dockerOptions, getter)

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -129,7 +129,7 @@ func NewRunner(ctx context.Context, options *core.PipelineOptions, dockerOptions
 		getPipeline:   getPipeline,
 		logger:        logger,
 		emitter:       e,
-		formatter:     &util.Formatter{options.GlobalOptions.ShowColors},
+		formatter:     &util.Formatter{ShowColors: options.GlobalOptions.ShowColors},
 	}, nil
 }
 
@@ -465,7 +465,7 @@ func (p *Runner) StartFullPipeline(options *core.PipelineOptions) *util.Finisher
 // the entire "Setup Environment" step.
 func (p *Runner) SetupEnvironment(runnerCtx context.Context) (*RunnerShared, error) {
 	shared := &RunnerShared{}
-	f := &util.Formatter{p.options.GlobalOptions.ShowColors}
+	f := &util.Formatter{ShowColors: p.options.GlobalOptions.ShowColors}
 	timer := util.NewTimer()
 
 	sr := &StepResult{

--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -191,7 +191,7 @@ func (p *BasePipeline) SetupGuest(sessionCtx context.Context, sess *Session) err
 	defer sess.ShowLogs()
 
 	timer := util.NewTimer()
-	f := &util.Formatter{p.options.GlobalOptions.ShowColors}
+	f := &util.Formatter{ShowColors: p.options.GlobalOptions.ShowColors}
 
 	cmds := []string{}
 

--- a/docker/options.go
+++ b/docker/options.go
@@ -46,7 +46,7 @@ func guessAndUpdateDockerOptions(opts *Options, e *util.Environment) {
 
 	logger := util.RootLogger().WithField("Logger", "docker")
 	// f := &util.Formatter{opts.GlobalOptions.ShowColors}
-	f := &util.Formatter{false}
+	f := &util.Formatter{ShowColors: false}
 
 	// Check the unix socket, default on linux
 	// This will fail instantly so don't bother with the goroutine

--- a/docker/watchstep.go
+++ b/docker/watchstep.go
@@ -264,7 +264,7 @@ func (s *WatchStep) Execute(ctx context.Context, sess *core.Session) (int, error
 		s.killProcesses(containerID, "INT")
 		return 0, nil
 	}
-	f := &util.Formatter{s.options.GlobalOptions.ShowColors}
+	f := &util.Formatter{ShowColors: s.options.GlobalOptions.ShowColors}
 	s.logger.Info(f.Info("Reloading on file changes"))
 	doCmd := func() {
 		err := sess.Send(ctx, false, "set +e", s.Code)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -403,94 +403,94 @@
 			"revisionTime": "2016-03-30T01:14:24Z"
 		},
 		{
-			"checksumSHA1": "Nyr+4t9GJOoIZjc5yjlEJVcCvD0=",
+			"checksumSHA1": "RjJc2krwXV0G5hhkOhxqGXY6fUc=",
 			"path": "github.com/cloudflare/cfssl/api",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
 			"checksumSHA1": "WHWr6czyM625XVdvPN17B50ovrk=",
 			"path": "github.com/cloudflare/cfssl/auth",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
-			"checksumSHA1": "XGai1k/Xrnt0URW6RsjDfdMifj0=",
+			"checksumSHA1": "duxfb/cka4fBVgW0wSchulpGVcE=",
 			"path": "github.com/cloudflare/cfssl/certdb",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
-			"checksumSHA1": "ZO0bAwayr/g7DDbKPfQO6by45zY=",
+			"checksumSHA1": "avdFEKaQPxKujTLcA1ec/bpN7tQ=",
 			"path": "github.com/cloudflare/cfssl/config",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
-			"checksumSHA1": "pM8P41YXPXeR01LTnKZXSakd31w=",
+			"checksumSHA1": "mdeqE00nlroD2prYypxQEc8NcCk=",
 			"path": "github.com/cloudflare/cfssl/crypto/pkcs7",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
-			"checksumSHA1": "Z6TXyKparO4tCzfyNHXa0fIZll8=",
+			"checksumSHA1": "HvR1PV4UK4nSzRiy6B4eSL6ua3M=",
 			"path": "github.com/cloudflare/cfssl/csr",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
-			"checksumSHA1": "3NOQWYL0w3zQS/qG7OkukhWVsSs=",
+			"checksumSHA1": "QXt1t33644YGvED5nxMKt6t+Y7k=",
 			"path": "github.com/cloudflare/cfssl/errors",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
-			"checksumSHA1": "zc72ofEGQVq4swmuKJFc03zJfcA=",
+			"checksumSHA1": "MZa28m7SeWMgOyWhW5wgU6Rhb1s=",
 			"path": "github.com/cloudflare/cfssl/helpers",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
 			"checksumSHA1": "hrI9ZAcwbjQ0FVHrpkxIKk4PdfQ=",
 			"path": "github.com/cloudflare/cfssl/helpers/derhelpers",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
 			"checksumSHA1": "nbzsp45GyLeosQUqpNT9fWc1q9U=",
 			"path": "github.com/cloudflare/cfssl/info",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
-			"checksumSHA1": "VsabOZi+z4eu74pTLq6bzbO1bxM=",
+			"checksumSHA1": "vjQYBl9tKQ47pLx74fAacsK2ulM=",
 			"path": "github.com/cloudflare/cfssl/initca",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
-			"checksumSHA1": "KGqB1RhhfIljSlyiYI/Kk/H3ins=",
+			"checksumSHA1": "bsjay99yxrifdZ6PeqWaTkuB/kk=",
 			"path": "github.com/cloudflare/cfssl/log",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
 			"checksumSHA1": "OKh9Jo5QeZhPOWkoseDc0J8U1LM=",
 			"path": "github.com/cloudflare/cfssl/ocsp/config",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
-			"checksumSHA1": "SAoVBNjHfOp8RUVvEsnlwsOjr5c=",
+			"checksumSHA1": "iQ6Gj2Gpb+jYunVfZRKXGYmdQ/8=",
 			"path": "github.com/cloudflare/cfssl/signer",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
-			"checksumSHA1": "sbZjPoZgXIYSx8xw7ofyGkaUdus=",
+			"checksumSHA1": "wv9jOsPhojJ+ceO5r6k9ZPTI+Bw=",
 			"path": "github.com/cloudflare/cfssl/signer/local",
-			"revision": "db0d0650b6496bfe8061ec56a92edd32d8e75c30",
-			"revisionTime": "2016-03-30T01:14:24Z"
+			"revision": "74f2ddc212e277519d83f942a8efd3bb9e243f16",
+			"revisionTime": "2018-03-01T21:28:15Z"
 		},
 		{
 			"checksumSHA1": "OIMQkl9E8WtJhZvYkg4o5yOd5Sw=",
@@ -1282,106 +1282,112 @@
 			"revisionTime": "2017-08-15T08:56:58Z"
 		},
 		{
-			"checksumSHA1": "l/a/XlzAQfUCP3a4POXGhxkJXug=",
+			"checksumSHA1": "fbMBM0Rh4fH554O3fDMvXT5jnwo=",
 			"path": "github.com/golang/protobuf/proto",
-			"revision": "ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e",
-			"revisionTime": "2017-08-16T00:15:14Z"
+			"revision": "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175",
+			"revisionTime": "2018-02-02T18:43:18Z"
 		},
 		{
 			"checksumSHA1": "qyalT+838zrkZMjOA62VGus0VcI=",
 			"path": "github.com/golang/protobuf/proto/proto3_proto",
-			"revision": "ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e",
-			"revisionTime": "2017-08-16T00:15:14Z"
+			"revision": "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175",
+			"revisionTime": "2018-02-02T18:43:18Z"
 		},
 		{
 			"checksumSHA1": "ykKFnDOqloGM/pABMjTWkSrXmrw=",
 			"path": "github.com/golang/protobuf/proto/testdata",
-			"revision": "ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e",
-			"revisionTime": "2017-08-16T00:15:14Z"
+			"revision": "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175",
+			"revisionTime": "2018-02-02T18:43:18Z"
 		},
 		{
-			"checksumSHA1": "haP5YgoPcGgm3e0QHByz89T7rGI=",
+			"checksumSHA1": "XNHQiRltA7NQJV0RvUroY+cf+zg=",
 			"path": "github.com/golang/protobuf/protoc-gen-go/descriptor",
-			"revision": "ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e",
-			"revisionTime": "2017-08-16T00:15:14Z"
+			"revision": "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175",
+			"revisionTime": "2018-02-02T18:43:18Z"
 		},
 		{
 			"checksumSHA1": "p8EG/0ssb7O49fYv1DfxbhDXiUw=",
 			"path": "github.com/golang/protobuf/ptypes",
-			"revision": "ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e",
-			"revisionTime": "2017-08-16T00:15:14Z"
+			"revision": "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175",
+			"revisionTime": "2018-02-02T18:43:18Z"
 		},
 		{
-			"checksumSHA1": "CUN+8uU3mWzv9JNB2RXTefAuBb4=",
+			"checksumSHA1": "UB9scpDxeFjQe5tEthuR4zCLRu4=",
 			"path": "github.com/golang/protobuf/ptypes/any",
-			"revision": "ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e",
-			"revisionTime": "2017-08-16T00:15:14Z"
+			"revision": "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175",
+			"revisionTime": "2018-02-02T18:43:18Z"
 		},
 		{
 			"checksumSHA1": "hUjAj0dheFVDl84BAnSWj9qy2iY=",
 			"path": "github.com/golang/protobuf/ptypes/duration",
-			"revision": "ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e",
-			"revisionTime": "2017-08-16T00:15:14Z"
+			"revision": "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175",
+			"revisionTime": "2018-02-02T18:43:18Z"
 		},
 		{
 			"checksumSHA1": "O2ItP5rmfrgxPufhjJXbFlXuyL8=",
 			"path": "github.com/golang/protobuf/ptypes/timestamp",
-			"revision": "ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e",
-			"revisionTime": "2017-08-16T00:15:14Z"
+			"revision": "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175",
+			"revisionTime": "2018-02-02T18:43:18Z"
 		},
 		{
-			"checksumSHA1": "ALW0Iq2+QjwSr84HRHeajs2n9LY=",
+			"checksumSHA1": "qp5RRqPMl2JcyB1fAKnU9ZwxVkc=",
 			"path": "github.com/google/certificate-transparency-go",
-			"revision": "4db422c9c518077714d9c75a111ff993876d83b9",
-			"revisionTime": "2017-08-22T13:03:25Z"
+			"revision": "d5adc9b1321210597b7035d84fcac4ec60da621c",
+			"revisionTime": "2018-03-01T15:03:37Z"
 		},
 		{
-			"checksumSHA1": "5b/AV9svL/x6rWfcTDV1rfMql8Q=",
+			"checksumSHA1": "DUWCoXjVfhns4xhhybEqwEj8dVY=",
 			"path": "github.com/google/certificate-transparency-go/asn1",
-			"revision": "4db422c9c518077714d9c75a111ff993876d83b9",
-			"revisionTime": "2017-08-22T13:03:25Z"
+			"revision": "d5adc9b1321210597b7035d84fcac4ec60da621c",
+			"revisionTime": "2018-03-01T15:03:37Z"
 		},
 		{
-			"checksumSHA1": "pLVrktB5FjhihIOW4CI3xMme4ck=",
+			"checksumSHA1": "5T1K4VQuZEVuxAwlnkFKS7HrRbI=",
 			"path": "github.com/google/certificate-transparency-go/client",
-			"revision": "4db422c9c518077714d9c75a111ff993876d83b9",
-			"revisionTime": "2017-08-22T13:03:25Z"
+			"revision": "d5adc9b1321210597b7035d84fcac4ec60da621c",
+			"revisionTime": "2018-03-01T15:03:37Z"
 		},
 		{
-			"checksumSHA1": "4ZM9WhtDQAP4o/cPtskSkLFeKZ0=",
+			"checksumSHA1": "sb1mCLUWEdBksGx4s2k0SEbwanw=",
+			"path": "github.com/google/certificate-transparency-go/client/configpb",
+			"revision": "d5adc9b1321210597b7035d84fcac4ec60da621c",
+			"revisionTime": "2018-03-01T15:03:37Z"
+		},
+		{
+			"checksumSHA1": "sRviQPTRe71sv3LM+iSRp0/W324=",
 			"path": "github.com/google/certificate-transparency-go/fixchain",
-			"revision": "4db422c9c518077714d9c75a111ff993876d83b9",
-			"revisionTime": "2017-08-22T13:03:25Z"
+			"revision": "d5adc9b1321210597b7035d84fcac4ec60da621c",
+			"revisionTime": "2018-03-01T15:03:37Z"
 		},
 		{
-			"checksumSHA1": "FmwmHER3kMLGtw0+RM333olsLAM=",
+			"checksumSHA1": "2h7JVgtv7LE8V4hnXdLWYePxP64=",
 			"path": "github.com/google/certificate-transparency-go/jsonclient",
-			"revision": "4db422c9c518077714d9c75a111ff993876d83b9",
-			"revisionTime": "2017-08-22T13:03:25Z"
+			"revision": "d5adc9b1321210597b7035d84fcac4ec60da621c",
+			"revisionTime": "2018-03-01T15:03:37Z"
 		},
 		{
-			"checksumSHA1": "OicVLiV2fJgpFmx+5Ka89Ail7ec=",
+			"checksumSHA1": "VRe580bpCrpLEc86E0ThUBv+3BM=",
 			"path": "github.com/google/certificate-transparency-go/testdata",
-			"revision": "4db422c9c518077714d9c75a111ff993876d83b9",
-			"revisionTime": "2017-08-22T13:03:25Z"
+			"revision": "d5adc9b1321210597b7035d84fcac4ec60da621c",
+			"revisionTime": "2018-03-01T15:03:37Z"
 		},
 		{
-			"checksumSHA1": "wbCqyIUXELGkfwYZmWPZh5VCKMY=",
+			"checksumSHA1": "zub0+LwtY3w0KQHoPGV2SKD/+h8=",
 			"path": "github.com/google/certificate-transparency-go/tls",
-			"revision": "4db422c9c518077714d9c75a111ff993876d83b9",
-			"revisionTime": "2017-08-22T13:03:25Z"
+			"revision": "d5adc9b1321210597b7035d84fcac4ec60da621c",
+			"revisionTime": "2018-03-01T15:03:37Z"
 		},
 		{
-			"checksumSHA1": "8urn9sLHxbvpRk2pnfGvw5UJPxE=",
+			"checksumSHA1": "sUPJ6MZt5LZD1Ojd9RfyXXxgZBk=",
 			"path": "github.com/google/certificate-transparency-go/x509",
-			"revision": "4db422c9c518077714d9c75a111ff993876d83b9",
-			"revisionTime": "2017-08-22T13:03:25Z"
+			"revision": "d5adc9b1321210597b7035d84fcac4ec60da621c",
+			"revisionTime": "2018-03-01T15:03:37Z"
 		},
 		{
-			"checksumSHA1": "Wq/w8Q1H/QEzUs+FIkhhxrmMHiA=",
+			"checksumSHA1": "MY2Wckh2xLLhwP+BX4iqHJMStK0=",
 			"path": "github.com/google/certificate-transparency-go/x509/pkix",
-			"revision": "4db422c9c518077714d9c75a111ff993876d83b9",
-			"revisionTime": "2017-08-22T13:03:25Z"
+			"revision": "d5adc9b1321210597b7035d84fcac4ec60da621c",
+			"revisionTime": "2018-03-01T15:03:37Z"
 		},
 		{
 			"checksumSHA1": "FimZS1Vr+JZqBVPd1Ya/TH3NGOE=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2042,6 +2042,18 @@
 			"revisionTime": "2017-08-23T13:44:09Z"
 		},
 		{
+			"checksumSHA1": "tz9tF0a0wGc+Z0FBPQinsJzAt4g=",
+			"path": "golang.org/x/crypto/cryptobyte",
+			"revision": "b2aa35443fbc700ab74c586ae79b81c171851023",
+			"revisionTime": "2018-04-03T08:00:15Z"
+		},
+		{
+			"checksumSHA1": "YEoV2AiZZPDuF7pMVzDt7buS9gc=",
+			"path": "golang.org/x/crypto/cryptobyte/asn1",
+			"revision": "b2aa35443fbc700ab74c586ae79b81c171851023",
+			"revisionTime": "2018-04-03T08:00:15Z"
+		},
+		{
 			"checksumSHA1": "MB9kp6kGFizrcrHxDztThSVKanQ=",
 			"path": "golang.org/x/crypto/ocsp",
 			"revision": "eb71ad9bd329b5ac0fd0148dd99bd62e8be8e035",

--- a/wercker.yml
+++ b/wercker.yml
@@ -17,7 +17,7 @@ build:
         code: govendor sync
 
     - script:
-        name: go vet
+        name: go vet -composites=false
         code: govendor vet +local
 
     # - golint:

--- a/wercker.yml
+++ b/wercker.yml
@@ -18,7 +18,7 @@ build:
 
     - script:
         name: go vet -composites=false
-        code: govendor vet +local
+        code: govendor vet -composites=false +local
 
     # - golint:
     #     exclude: vendor

--- a/wercker.yml
+++ b/wercker.yml
@@ -14,11 +14,11 @@ build:
     
     - script:
         name: install dependencies
-        code: govendor sync 
+        code: govendor sync
 
     - script:
         name: go vet
-        code: govendor vet +local    
+        code: govendor vet +local
 
     # - golint:
     #     exclude: vendor

--- a/wercker.yml
+++ b/wercker.yml
@@ -11,14 +11,14 @@ build:
     - script:
         name: install govendor
         code: go get -u github.com/kardianos/govendor
+    
+    - script:
+        name: install dependencies
+        code: govendor sync 
 
     - script:
         name: go vet
         code: govendor vet +local    
-     
-    - script:
-        name: install dependencies
-        code: govendor sync
 
     # - golint:
     #     exclude: vendor

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: golang:1.7
+box: golang:1.10
 no-response-timeout: 15
 
 build:
@@ -6,11 +6,15 @@ build:
   steps:
     - install-packages:
         checkpoint: pkgs
-        packages: openssh-client pkg-config libsystemd-journal-dev
+        packages: openssh-client pkg-config libsystemd-dev
 
     - script:
         name: install govendor
         code: go get -u github.com/kardianos/govendor
+     
+    - script:
+        name: install dependencies
+        code: govendor sync
 
     - script:
         name: go vet
@@ -18,10 +22,6 @@ build:
 
     # - golint:
     #     exclude: vendor
-
-    - script:
-        name: install dependencies
-        code: govendor sync
 
     - script:
         name: go test

--- a/wercker.yml
+++ b/wercker.yml
@@ -11,14 +11,14 @@ build:
     - script:
         name: install govendor
         code: go get -u github.com/kardianos/govendor
+
+    - script:
+        name: go vet
+        code: govendor vet +local    
      
     - script:
         name: install dependencies
         code: govendor sync
-
-    - script:
-        name: go vet -composites=false
-        code: govendor vet -composites=false +local
 
     # - golint:
     #     exclude: vendor


### PR DESCRIPTION
**What this PR does / why we need it:**
Fixes [353](https://github.com/wercker/wercker/issues/353)
To make "go build" and "wercker build" work with golang 1.10 following changes were required to be done

- Updates to few cfssl, certificate-transparaency-go and related dependencies in vendor.json as per https://github.com/google/certificate-transparency-go/issues/153
- Updates to vendor.json to fetch golang.org/x/crypto/cryptobyte as mentioned in this post https://github.com/google/certificate-transparency-go/issues/153#issuecomment-370893611
- From golang version 1.10 - go vet also looks for package dependencies being available (as mentioned in release notes - https://golang.org/doc/go1.10#vet. Therefore an update was made to wercker.yml to invoke "govendor sync" before "govendor vet"
- In new go vet , Unkeyed composite literals are being flagged as mentioned in https://golang.org/cmd/vet/#hdr-Unkeyed_composite_literals - we use this at several places as mentioned below:

1. github.com/wercker/wercker/core
core/pipeline.go:194: github.com/wercker/wercker/util.Formatter composite literal uses unkeyed fields
2. github.com/wercker/wercker/docker
docker/options.go:49: github.com/wercker/wercker/util.Formatter composite literal uses unkeyed fields
docker/watchstep.go:267: github.com/wercker/wercker/util.Formatter composite literal uses unkeyed fields
3. github.com/wercker/wercker/cmd
cmd/main.go:932: github.com/wercker/wercker/util.Formatter composite literal uses unkeyed fields
cmd/runner.go:132: github.com/wercker/wercker/util.Formatter composite literal uses unkeyed fields
cmd/runner.go:468: github.com/wercker/wercker/util.Formatter composite literal uses unkeyed fields
 
Since it is a valid construct - to disable the warning added -compoistes=false to govendor vet. More [here](https://stackoverflow.com/questions/36273920/disable-go-vet-checks-for-composite-literal-uses-unkeyed-fields) 

-  Replaced libsystemd-dev for libsystemd-journal-dev due to following message after updating the box to golang 1.10
"Package libsystemd-journal-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libsystemd-dev"

Have been tested by running couple of builds against canary staged version of wercker built after these changes