### PR TITLE
Fix #1740 - Correctly infer registry and repository from step input

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ## unreleased
 
+- Fix for correctly inferring regsitry and repoistory from step inputs (#375) 
 - Fix "go build" and "wercker build" on golang 1.10 (#374)
 
 ## v1.0.1189(2018-04-04)

--- a/docker/box.go
+++ b/docker/box.go
@@ -550,7 +550,12 @@ func (b *DockerBox) Fetch(ctx context.Context, env *util.Environment) (*docker.I
 
 	// If user use Azure or AWS container registry we don't infer.
 	if b.config.Auth.AzureClientSecret == "" && b.config.Auth.AwsSecretKey == "" {
-		repo, b.config.Auth = InferRegistry(repo, b.config.Auth, b.options)
+		repository, registry, err := InferRegistryAndRepository(repo, b.config.Auth.Registry, b.options)
+		if err != nil {
+			return nil, err
+		}
+		repo = repository
+		b.config.Auth.Registry = registry
 	}
 
 	if b.config.Auth.Registry == b.options.WerckerContainerRegistry.String() {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1153,11 +1153,12 @@ func (s *DockerPushStep) tagAndPush(imageID string, e *core.NormalizedEmitter, c
 				if statusMessage.Aux != nil && statusMessage.Aux.Tag == tag {
 					s.logger.Println("Pushed container:", s.repository, tag, ",Digest:", statusMessage.Aux.Digest)
 					e.Emit(core.Logs, &core.LogsArgs{
-						Logs: fmt.Sprintf("Pushed %s:%s", s.repository, tag),
+						Logs: fmt.Sprintf("\n Pushed %s:%s", s.repository, tag),
 					})
 					isContainerPushed = true
 				}
 
+				s
 			}
 			if !isContainerPushed {
 				s.logger.Errorln("Failed to push tag:", tag, "Please check log messages")

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1153,7 +1153,7 @@ func (s *DockerPushStep) tagAndPush(imageID string, e *core.NormalizedEmitter, c
 				if statusMessage.Aux != nil && statusMessage.Aux.Tag == tag {
 					s.logger.Println("Pushed container:", s.repository, tag, ",Digest:", statusMessage.Aux.Digest)
 					e.Emit(core.Logs, &core.LogsArgs{
-						Logs: fmt.Sprintf("Pushed %s:%s", s.repository, tag),
+						Logs: fmt.Sprintf("\nPushed %s:%s", s.repository, tag),
 					})
 					isContainerPushed = true
 				}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1157,8 +1157,6 @@ func (s *DockerPushStep) tagAndPush(imageID string, e *core.NormalizedEmitter, c
 					})
 					isContainerPushed = true
 				}
-
-				s
 			}
 			if !isContainerPushed {
 				s.logger.Errorln("Failed to push tag:", tag, "Please check log messages")

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1152,6 +1152,9 @@ func (s *DockerPushStep) tagAndPush(imageID string, e *core.NormalizedEmitter, c
 				}
 				if statusMessage.Aux != nil && statusMessage.Aux.Tag == tag {
 					s.logger.Println("Pushed container:", s.repository, tag, ",Digest:", statusMessage.Aux.Digest)
+					e.Emit(core.Logs, &core.LogsArgs{
+						Logs: fmt.Sprintf("Pushed %s:%s", s.repository, tag),
+					})
 					isContainerPushed = true
 				}
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1153,7 +1153,7 @@ func (s *DockerPushStep) tagAndPush(imageID string, e *core.NormalizedEmitter, c
 				if statusMessage.Aux != nil && statusMessage.Aux.Tag == tag {
 					s.logger.Println("Pushed container:", s.repository, tag, ",Digest:", statusMessage.Aux.Digest)
 					e.Emit(core.Logs, &core.LogsArgs{
-						Logs: fmt.Sprintf("\n Pushed %s:%s", s.repository, tag),
+						Logs: fmt.Sprintf("Pushed %s:%s", s.repository, tag),
 					})
 					isContainerPushed = true
 				}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -918,14 +918,14 @@ func (s *DockerPushStep) buildAutherOpts(env *util.Environment) dockerauth.Check
 //    and https://quay.io/v2/ will be the registry url. In case the repository name does not contain a domain name -
 //    docker hub is assumed to be the registry and therefore any authorization with supplied username/password is carried
 //    out with docker hub.
-// 4. In case both repository and registry are provided -
-//    4(a) - In case registry provided points to a wrong url - we use registry inferred from the domain name(if any) prefixed
+// 3. In case both repository and registry are provided -
+//    3(a) - In case registry provided points to a wrong url - we use registry inferred from the domain name(if any) prefixed
 //           to the repository. However in this case if no domain name is specified in repository - we return an error since
 //           user probably wanted to use this repository with a different registry and not docker hub and should be alerted
 //           that the registry url is invalid.In case registry url is valid - we evaluate scenarios 4(b) and 4(c)
-//    4(b) - In case no domain name is prefixed to the repository - we assume repository belongs to the registry specified
+//    3(b) - In case no domain name is prefixed to the repository - we assume repository belongs to the registry specified
 //           and prefix domain name extracted from registry.
-//    4(c) - In case repository also contains a domain name - we check if domain name of registry and repository are same,
+//    3(c) - In case repository also contains a domain name - we check if domain name of registry and repository are same,
 //           we assume that user wanted to use the registry host as specified in repository and change the registry to point
 //           to domain name present in repository. If domain names in both registry and repository are same - no changes are
 //           made.

--- a/docker/docker_push_test.go
+++ b/docker/docker_push_test.go
@@ -83,9 +83,11 @@ func (s *PushSuite) TestInferRegistry() {
 			ApplicationName:          "appname",
 			WerckerContainerRegistry: testWerckerRegistry,
 		}
-		repo, opts := InferRegistry(tt.repository, dockerauth.CheckAccessOptions{
+		opts := dockerauth.CheckAccessOptions{
 			Registry: tt.registry,
-		}, options)
+		}
+		repo, registry, _ := InferRegistryAndRepository(tt.repository, opts.Registry, options)
+		opts.Registry = registry
 		s.Equal(tt.expectedRegistry, opts.Registry, "%q, wants %q", opts.Registry, tt.expectedRegistry)
 		s.Equal(tt.expectedRepository, repo, "%q, wants %q", repo, tt.expectedRepository)
 	}

--- a/docker/docker_push_test.go
+++ b/docker/docker_push_test.go
@@ -63,7 +63,7 @@ func (s *PushSuite) TestEmptyPush() {
 	s.Equal([]string{"latest", "master-s4k2r0d6a9b"}, tags)
 }
 
-func (s *PushSuite) TestInferRegistry() {
+func (s *PushSuite) TestInferRegistryAndRepository() {
 	testWerckerRegistry, _ := url.Parse("https://test.wcr.io/v2")
 	repoTests := []struct {
 		registry           string
@@ -72,9 +72,13 @@ func (s *PushSuite) TestInferRegistry() {
 		expectedRepository string
 	}{
 		{"", "appowner/appname", "", "appowner/appname"},
-		{"", "", testWerckerRegistry.String() + "/", testWerckerRegistry.Host + "/appowner/appname"},
+		{"", "", testWerckerRegistry.String(), testWerckerRegistry.Host + "/appowner/appname"},
 		{"", "someregistry.com/appowner/appname", "https://someregistry.com/v2/", "someregistry.com/appowner/appname"},
 		{"", "appOWNER/appname", "", "appowner/appname"},
+		{"https://someregistry.com", "appowner/appname", "https://someregistry.com", "someregistry.com/appowner/appname"},
+		{"https://someregistry.com/v1", "appowner/appname", "https://someregistry.com/v1", "someregistry.com/appowner/appname"},
+		{"https://someregistry.com/v2", "appowner/appname", "https://someregistry.com/v2", "someregistry.com/appowner/appname"},
+		{"https://someregistry.com", "someotherregistry.com/appowner/appname", "https://someotherregistry.com/v2/", "someotherregistry.com/appowner/appname"},
 	}
 
 	for _, tt := range repoTests {

--- a/docker/docker_push_test.go
+++ b/docker/docker_push_test.go
@@ -79,6 +79,7 @@ func (s *PushSuite) TestInferRegistryAndRepository() {
 		{"https://someregistry.com/v1", "appowner/appname", "https://someregistry.com/v1", "someregistry.com/appowner/appname"},
 		{"https://someregistry.com/v2", "appowner/appname", "https://someregistry.com/v2", "someregistry.com/appowner/appname"},
 		{"https://someregistry.com", "someotherregistry.com/appowner/appname", "https://someotherregistry.com/v2/", "someotherregistry.com/appowner/appname"},
+		{"https://someregistry.com", "appowner/appname", "https://someregistry.com", "someregistry.com/appowner/appname"},
 	}
 
 	for _, tt := range repoTests {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2018,12 +2018,10 @@
 			"revisionTime": "2017-07-07T00:42:18Z"
 		},
 		{
-			"checksumSHA1": "q2XkJNw0V5S1nn8tPp85PnEj3pw=",
+			"checksumSHA1": "hwuhOL78FeNle4mOksY8Bx+5j3k=",
 			"path": "github.com/wercker/docker-check-access",
-			"revision": "7b33d11ab7c4a7b3cc11c834e7b0836241c7e86c",
-			"revisionTime": "2018-04-05T08:19:24Z",
-			"version": "=issue-1740",
-			"versionExact": "issue-1740"
+			"revision": "6de3890fc137c624884041d0af695128cb6db976",
+			"revisionTime": "2018-04-10T06:27:42Z"
 		},
 		{
 			"checksumSHA1": "rpIHxVmXHbM31S0S/2qE1kAvzfw=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2012,10 +2012,12 @@
 			"revisionTime": "2017-07-07T00:42:18Z"
 		},
 		{
-			"checksumSHA1": "A1URpbCn/U2p4cQVPdHrJmMKO0k=",
+			"checksumSHA1": "q2XkJNw0V5S1nn8tPp85PnEj3pw=",
 			"path": "github.com/wercker/docker-check-access",
-			"revision": "1af20977034e948bd4f9ec049bda2e2dd0ffb3ca",
-			"revisionTime": "2017-08-24T14:37:00Z"
+			"revision": "7b33d11ab7c4a7b3cc11c834e7b0836241c7e86c",
+			"revisionTime": "2018-04-05T08:19:24Z",
+			"version": "=issue-1740",
+			"versionExact": "issue-1740"
 		},
 		{
 			"checksumSHA1": "rpIHxVmXHbM31S0S/2qE1kAvzfw=",


### PR DESCRIPTION
**What this PR does / why we need it:**
Fixes [1740](https://github.com/wercker/backlog/issues/1740) 
Existing logic to infer the correct registry URL from repository and registry fields from step configuration was not consistent as mentioned in issue description. With this change

1. If no repository is specified, it is assumed that the user wants to push an image of current application for which  the build is running to wcr.io repository and therefore registry is inferred as
https://test.wcr.io/v2 and repository as test.wcr.io/<application-owner>/<application-name>
2. In case a repository is provided but no registry - registry is derived from the name of the domain (if any) from the registry - e.g. for a repository quay.io/<repo-owner>/<repo-name> - quay.io will be the registry host and https://quay.io/v2/ will be the registry url. In case the repository name does not contain a domain name - docker hub is assumed to be the registry and therefore any authorization with supplied username/password is carried out with docker hub.
3. In case both repository and registry are provided -
   3(a) - In case registry provided points to a wrong url - we use registry inferred from the domain name(if any) prefixed to the repository. However in this case if no domain name is specified in repository - we return an error since user probably wanted to use this repository with a different registry and not docker hub and should be alerted that the registry url is invalid.In case registry url is valid - we evaluate scenarios 4(b) and 4(c)
   3(b) - In case no domain name is prefixed to the repository - we assume repository belongs to the registry specified and prefix domain name extracted from registry.
   3(c) - In case repository also contains a domain name - we check if domain name of registry and repository are same, we assume that user wanted to use the registry host as specified in repository and change the registry to point to domain name present in repository. If domain names in both registry and repository are same - no changes are made.

- Changed method name to InferRegistryAndRepository and fixed the return types to correctly reflect what this method does
- Updated unit test cases for additional scenarios
- Fixed [comment on PR for 1741](https://github.com/wercker/wercker/pull/371#discussion_r179683496)
-  Added code to print repo:tag of pushed container in step logs
- vendor.json currently refers to [issue-1740 branch of docker-check-access](https://github.com/wercker/docker-check-access/tree/issue-1740)  which contain related changes as mentioned in this [PR](https://github.com/wercker/docker-check-access/pull/6) . Once that is merged - will change it back to refer to master of docker-check-access
- Have been tested using stage canary testing
