### PR TITLE
Production release for fix for issue #1740, PR#375 on wercker/wercker and PR#6 on docker-check-access -  Correctly infer registry and repository from step input

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+## v1.0.XXXX(2018-04-10)
+
 - Fix for correctly inferring regsitry and repoistory from step inputs (#375) 
 - Fix "go build" and "wercker build" on golang 1.10 (#374)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 ## unreleased
 
-## v1.0.XXXX(2018-04-10)
+## v1.0.1195(2018-04-10)
 
 - Fix for correctly inferring regsitry and repoistory from step inputs (#375) 
 - Fix "go build" and "wercker build" on golang 1.10 (#374)


### PR DESCRIPTION
Production release for fix for issue [1740](https://github.com/wercker/backlog/issues/1740)
Merged PR on wercker/wercker - #375 
Merged PR on wercker/docker-check-access  - [6](https://github.com/wercker/docker-check-access/pull/6)