### PR TITLE
New test for docker push that tests env and labels properties

### DIFF
--- a/test-all.sh
+++ b/test-all.sh
@@ -113,6 +113,7 @@ testScratchPush () {
 
 runTests() {
 
+  source $testsDir/docker-push/test.sh || return 1
   source $testsDir/docker-build/test.sh || return 1
   source $testsDir/docker-push-image/test.sh || return 1
 

--- a/tests/projects/docker-push/Dockerfile
+++ b/tests/projects/docker-push/Dockerfile
@@ -1,0 +1,19 @@
+# Step #1 Run unit tests and build an executable that doesn't require the go libs
+FROM golang as firststage
+WORKDIR /work
+ADD . .
+RUN go test ./...
+RUN cat /etc/hosts # used to verify extrahosts
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o myapp .
+#
+# Step #2: Copy the executable into a minimal image (less than 5MB) 
+#         which doesn't contain the build tools and artifacts
+FROM alpine:latest  
+ARG foo
+ARG bar
+ENV foo=${foo}
+ENV bar=${bar}
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=firststage /work/myapp .
+CMD ["./myapp"]  

--- a/tests/projects/docker-push/Dockerfile
+++ b/tests/projects/docker-push/Dockerfile
@@ -9,10 +9,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o myapp .
 # Step #2: Copy the executable into a minimal image (less than 5MB) 
 #         which doesn't contain the build tools and artifacts
 FROM alpine:latest  
-ARG foo
-ARG bar
-ENV foo=${foo}
-ENV bar=${bar}
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=firststage /work/myapp .

--- a/tests/projects/docker-push/main.go
+++ b/tests/projects/docker-push/main.go
@@ -1,0 +1,44 @@
+//   Copyright © 2018, Oracle and/or its affiliates.  All rights reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+)
+
+// envHandler handles queries of the form /env/foo
+// foo is the name of an environment variable
+// and this handler returns its value
+func envHandler(res http.ResponseWriter, req *http.Request) {
+	varname := req.URL.Path[len("/env/"):]
+	value := os.Getenv(varname)
+	res.Header().Set("Content-Type", "application/json; charset=utf-8")
+	res.Write([]byte(value))
+}
+
+func defaultHandler(res http.ResponseWriter, req *http.Request) {
+	res.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	res.Write([]byte("Hello World!"))
+}
+
+func main() {
+	http.HandleFunc("/", defaultHandler)
+	http.HandleFunc("/env/", envHandler)
+	err := http.ListenAndServe(":5000", nil)
+	if err != nil {
+		log.Fatal("Unable to listen on port 5000 : ", err)
+	}
+}

--- a/tests/projects/docker-push/main_test.go
+++ b/tests/projects/docker-push/main_test.go
@@ -1,0 +1,30 @@
+//   Copyright © 2018, Oracle and/or its affiliates.  All rights reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleIndexReturnsWithStatusOK(t *testing.T) {
+	request, _ := http.NewRequest("GET", "/env/foo", nil)
+	response := httptest.NewRecorder()
+
+	envHandler(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("Non-expected status code%v:\n\tbody: %v", "200", response.Code)
+	}
+}

--- a/tests/projects/docker-push/test.sh
+++ b/tests/projects/docker-push/test.sh
@@ -78,7 +78,7 @@ testDockerPush () {
     echo "Unexpected response from test container for localhost:5000/env/foo " $curlOutput2
     return 1
   fi
-  if [ "$curlOutput3" != "val2" ]; then
+  if [ "$curlOutput3" != "Three word value" ]; then
     cat "${workingDir}/${testName}.log"
     echo "Unexpected response from test container for localhost:5000/env/bar " $curlOutput3
     return 1

--- a/tests/projects/docker-push/test.sh
+++ b/tests/projects/docker-push/test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# This is intended to be called from wercker/test-all.sh, which sets the required environment variables
+# if you run this file directly, you need to set $wercker, $workingDir and $testDir
+# as a convenience, if these are not set then assume we're running from the local directory 
+if [ -z ${wercker} ]; then wercker=$PWD/../../../wercker; fi
+if [ -z ${workingDir} ]; then workingDir=$PWD/../../../.werckertests; mkdir -p "$workingDir"; fi
+if [ -z ${testsDir} ]; then testsDir=$PWD/..; fi
+
+testDockerPush () {
+  testName=docker-push
+  testDir=$testsDir/docker-push
+  printf "testing %s... " "$testName"
+  # this test will create an image with the following repository: should match the repository setting in wercker.yml
+  repo=test-docker-push
+  # stop any existing container started by a previous run
+  docker kill ${testName}-container > /dev/null 2>&1
+  # delete any existing image built by a previous run
+  docker images | grep $repo | awk '{print $3}' | xargs -n1 docker rmi -f > /dev/null 2>&1
+  # check no existing image with the specified repository (column 1 is the repository)
+  docker images | awk '{print $1}' | grep -q "$repo"
+  if [ $? -eq 0 ]; then
+    echo "An image with repository $repo already exists"
+    return 1
+  fi
+  # now run the build pipeline - this creates an image with the specified repository setting
+  $wercker build "$testDir" --docker-local --working-dir "$workingDir" &> "${workingDir}/${testName}.log"
+  if [ $? -ne 0 ]; then
+    printf "failed\n"
+    if [ "${workingDir}/${testName}.log" ]; then
+      cat "${workingDir}/${testName}.log"
+    fi
+    return 1
+  fi
+  # verify that an image was created with the expected repository setting (column 1 is the repository)
+  label1=`docker images | awk '{print $1}' | grep -q "$repo"`
+  if [ $? -ne 0 ]; then
+    echo "An image with repository $repo was not found"
+    return 1
+  fi
+  # Verify that the labels have been set as specified 
+  val1Expected="value1"
+  val1Actual=`docker inspect ${repo}:latest -f '{{index .Config.Labels "Label1"}}'`
+  if [ $val1Actual != $val1Expected ]; then
+    echo "Label incorrect: expected " $val1Expected " but was " $val1Actual
+    return 1
+  fi 
+  val2Expected="value2"
+  val2Actual=`docker inspect ${repo}:latest -f '{{index .Config.Labels "Three word key"}}'`
+  if [ $val2Actual != $val2Expected ]; then
+    echo "Label incorrect: expected " $val2Expected " but was " $val2Actual
+    return 1
+  fi 
+  val3Expected="Three word value"
+  val3Actual=`docker inspect ${repo}:latest -f '{{index .Config.Labels "Label3"}}'`
+  if [ "$val3Actual" != "$val3Expected" ]; then
+    echo "Label incorrect: expected " $val3Expected " but was " $val3Actual
+    return 1
+  fi  
+  # start the image using the docker CLI
+  docker run --name ${testName}-container --rm -d -p 5000:5000 ${repo}:latest >> "${workingDir}/${testName}.log" 2>&1
+  # test the image
+  curlOutput1=`curl -s localhost:5000`         # should return "Hello World!"
+  curlOutput2=`curl -s localhost:5000/env/foo` # should return value of build-arg foo (set in wercker.yml)"
+  curlOutput3=`curl -s localhost:5000/env/bar` # should return value of build-arg bar (set in wercker.yml)"
+  # stop the container
+  docker kill ${testName}-container >> "${workingDir}/${testName}.log" 2>&1
+  # delete the image we've just created
+  docker images | grep $repo | awk '{print $3}' | xargs -n1 docker rmi -f >> "${workingDir}/${testName}.log" 2>&1
+  # now the container and image have been cleaned up, check whether the test worked
+  if [ "$curlOutput1" != "Hello World!" ]; then
+    cat "${workingDir}/${testName}.log"
+    echo "Unexpected response from test container for localhost:5000 " $curlOutput1
+    return 1
+  fi
+  if [ "$curlOutput2" != "val1" ]; then
+    cat "${workingDir}/${testName}.log"
+    echo "Unexpected response from test container for localhost:5000/env/foo " $curlOutput2
+    return 1
+  fi
+  if [ "$curlOutput3" != "val2" ]; then
+    cat "${workingDir}/${testName}.log"
+    echo "Unexpected response from test container for localhost:5000/env/bar " $curlOutput3
+    return 1
+  fi    
+  # test passed
+  #cat "${workingDir}/${testName}.log"
+  printf "passed\n"
+  return 0
+}
+
+testDockerPushAll () {
+  testDockerPush || return 1 
+}
+
+testDockerPushAll

--- a/tests/projects/docker-push/wercker.yml
+++ b/tests/projects/docker-push/wercker.yml
@@ -14,7 +14,7 @@ build:
         registry: https://hub.docker.com
         repository: test-docker-push
         tag: latest        
-        env: "foo=val1 bar=val2"
+        env: "foo=val1 bar='Three word value'"
         labels: "Label1=value1 'Three word key'=value2 Label3='Three word value'"
 
 

--- a/tests/projects/docker-push/wercker.yml
+++ b/tests/projects/docker-push/wercker.yml
@@ -1,0 +1,20 @@
+build:
+  box: golang
+  steps:
+    - script:
+        name: Build
+        code: go build -o app
+    - script:
+        name: Test
+        code: go test ./...     
+    - internal/docker-push: # this test must be run with --docker-local so it doesn't actually push to a remote registry
+        entrypoint: /pipeline/source/app
+        username: someuser
+        password: somepassword
+        registry: https://hub.docker.com
+        repository: test-docker-push
+        tag: latest        
+        env: "foo=val1 bar=val2"
+        labels: "Label1=value1 'Three word key'=value2 Label3='Three word value'"
+
+


### PR DESCRIPTION
This PR adds a new integration test for `docker-push`. This tests it in the "old" mode when it creates an image from the current container and pushes it. I added this in order to test the `env` and `labels` property, which I am documenting as part of https://github.com/wercker/backlog/issues/1676