### PR TITLE
Fix integration tests

### DIFF
--- a/tests/projects/docker-push/test.sh
+++ b/tests/projects/docker-push/test.sh
@@ -12,7 +12,7 @@ testDockerPush () {
   testDir=$testsDir/docker-push
   printf "testing %s... " "$testName"
   # this test will create an image with the following repository: should match the repository setting in wercker.yml
-  repo=hub.docker.com/test-docker-push
+  repo=my.registry.com/test-docker-push
   # stop any existing container started by a previous run
   docker kill ${testName}-container > /dev/null 2>&1
   # delete any existing image built by a previous run

--- a/tests/projects/docker-push/test.sh
+++ b/tests/projects/docker-push/test.sh
@@ -12,7 +12,7 @@ testDockerPush () {
   testDir=$testsDir/docker-push
   printf "testing %s... " "$testName"
   # this test will create an image with the following repository: should match the repository setting in wercker.yml
-  repo=my.registry.com/test-docker-push
+  repo=my.registry.com/someuser/test-docker-push
   # stop any existing container started by a previous run
   docker kill ${testName}-container > /dev/null 2>&1
   # delete any existing image built by a previous run

--- a/tests/projects/docker-push/test.sh
+++ b/tests/projects/docker-push/test.sh
@@ -12,7 +12,7 @@ testDockerPush () {
   testDir=$testsDir/docker-push
   printf "testing %s... " "$testName"
   # this test will create an image with the following repository: should match the repository setting in wercker.yml
-  repo=test-docker-push
+  repo=hub.docker.com/test-docker-push
   # stop any existing container started by a previous run
   docker kill ${testName}-container > /dev/null 2>&1
   # delete any existing image built by a previous run

--- a/tests/projects/docker-push/wercker.yml
+++ b/tests/projects/docker-push/wercker.yml
@@ -11,9 +11,8 @@ build:
         entrypoint: /pipeline/source/app
         username: someuser
         password: somepassword
-        registry: https://hub.docker.com
-        repository: test-docker-push
-        tag: latest        
+        repository: my.registry.com/test-docker-push
+        tag: latest      
         env: "foo=val1 bar='Three word value'"
         labels: "Label1=value1 'Three word key'=value2 Label3='Three word value'"
 

--- a/tests/projects/docker-push/wercker.yml
+++ b/tests/projects/docker-push/wercker.yml
@@ -11,7 +11,7 @@ build:
         entrypoint: /pipeline/source/app
         username: someuser
         password: somepassword
-        repository: my.registry.com/test-docker-push
+        repository: my.registry.com/someuser/test-docker-push
         tag: latest      
         env: "foo=val1 bar='Three word value'"
         labels: "Label1=value1 'Three word key'=value2 Label3='Three word value'"

--- a/tests/projects/multidb/wercker.yml
+++ b/tests/projects/multidb/wercker.yml
@@ -4,10 +4,10 @@ box:
 
 services:
   - name: red1
-    id: sutoiku/redis
+    id: redis
     cmd: redis-server
   - name: red2
-    id: sutoiku/redis
+    id: redis
     cmd: redis-server
 
 build:


### PR DESCRIPTION
This PR fixes two unrelated failures in the integration tests.

The change to `tests/projects/docker-push/test.sh` is needed following the merge of PR https://github.com/wercker/wercker/pull/377 with the merge of PR https://github.com/wercker/wercker/pull/375 . Previously the registry property was not prepended to the repository property when tagging the image. Now it is.

The change to `tests/projects/multidb/wercker.yml` is needed because this test previously pulled `sutoiku/redis`, which no longer exists on Docker Hub.
