### PR TITLE
Docker network

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 ## unreleased
 
+
+- Replace docker links with docker network (#382)
+
 ## v1.0.1201 (2018-04-16)
 
 - Update azure client to allow docker-push in all regions (#381)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,4 +1,4 @@
-//   Copyright 2016 Wercker Holding BV
+//   Copyright © 2016, 2018, Oracle and/or its affiliates.  All rights reserved.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -50,7 +50,7 @@ var (
 		cli.IntFlag{Name: "docker-kernel-memory", Usage: "Set docker kernel memory limit in MB NOTIMPLEMENTED", Hidden: true},
 		cli.BoolFlag{Name: "docker-cleanup-image", Usage: "Remove image from the Docker when finished pushing them", Hidden: true},
 		cli.StringFlag{Name: "docker-network", Value: "", Usage: "Docker network name.", EnvVar: "DOCKER_NETWORK"},
-		cli.BoolFlag{Name: "docker-network-rm", Usage: "Remove passed docker network", Hidden: true),
+		cli.BoolFlag{Name: "docker-network-rm", Usage: "Remove passed docker network", Hidden: true},
 	}
 
 	// These flags control where we store local files

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -49,7 +49,7 @@ var (
 		cli.IntFlag{Name: "docker-memory-reservation", Usage: "Set docker user memory soft limit in MB NOTIMPLEMENTED", Hidden: true},
 		cli.IntFlag{Name: "docker-kernel-memory", Usage: "Set docker kernel memory limit in MB NOTIMPLEMENTED", Hidden: true},
 		cli.BoolFlag{Name: "docker-cleanup-image", Usage: "Remove image from the Docker when finished pushing them", Hidden: true},
-		cli.StringFlag{Name: "docker-network", Value: "", Usage: "Docker network name.", EnvVar: "DOCKER_NETWORK"},
+		cli.StringFlag{Name: "docker-network", Value: "", Usage: "Docker network name.", Hidden: true},
 	}
 
 	// These flags control where we store local files

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -50,7 +50,6 @@ var (
 		cli.IntFlag{Name: "docker-kernel-memory", Usage: "Set docker kernel memory limit in MB NOTIMPLEMENTED", Hidden: true},
 		cli.BoolFlag{Name: "docker-cleanup-image", Usage: "Remove image from the Docker when finished pushing them", Hidden: true},
 		cli.StringFlag{Name: "docker-network", Value: "", Usage: "Docker network name.", EnvVar: "DOCKER_NETWORK"},
-		cli.BoolFlag{Name: "docker-network-rm", Usage: "Remove passed docker network", Hidden: true},
 	}
 
 	// These flags control where we store local files

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -49,6 +49,8 @@ var (
 		cli.IntFlag{Name: "docker-memory-reservation", Usage: "Set docker user memory soft limit in MB NOTIMPLEMENTED", Hidden: true},
 		cli.IntFlag{Name: "docker-kernel-memory", Usage: "Set docker kernel memory limit in MB NOTIMPLEMENTED", Hidden: true},
 		cli.BoolFlag{Name: "docker-cleanup-image", Usage: "Remove image from the Docker when finished pushing them", Hidden: true},
+		cli.StringFlag{Name: "docker-network", Value: "", Usage: "Docker network name.", EnvVar: "DOCKER_NETWORK"},
+		cli.BoolFlag{Name: "docker-network-rm", Usage: "Remove passed docker network", Hidden: true),
 	}
 
 	// These flags control where we store local files

--- a/core/service.go
+++ b/core/service.go
@@ -22,9 +22,10 @@ import (
 
 // ServiceBox interface to services
 type ServiceBox interface {
-	Run(context.Context, *util.Environment, []string) (*docker.Container, error)
+	Run(context.Context, *util.Environment) (*docker.Container, error)
 	Fetch(ctx context.Context, env *util.Environment) (*docker.Image, error)
 	Link() string
 	GetID() string
 	GetName() string
+	GetServiceName() string
 }

--- a/core/service.go
+++ b/core/service.go
@@ -1,4 +1,4 @@
-//   Copyright 2016 Wercker Holding BV
+//   Copyright © 2016, 2018, Oracle and/or its affiliates.  All rights reserved.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -24,8 +24,7 @@ import (
 type ServiceBox interface {
 	Run(context.Context, *util.Environment) (*docker.Container, error)
 	Fetch(ctx context.Context, env *util.Environment) (*docker.Image, error)
-	Link() string
 	GetID() string
 	GetName() string
-	GetServiceName() string
+	GetServiceAlias() string
 }

--- a/docker/box.go
+++ b/docker/box.go
@@ -680,7 +680,7 @@ func (b *DockerBox) createDockerNetwork() (*docker.Network, error) {
 	b.logger.Debugln("Creating docker network")
 	client := b.client
 	return client.CreateNetwork(docker.CreateNetworkOptions{
-		Name:           b.options.RunID,
+		Name:           b.getNetworkName(),
 		CheckDuplicate: true,
 	})
 }
@@ -724,4 +724,9 @@ func (b *DockerBox) prepareSvcDockerEnvVar(env *util.Environment) ([]string, err
 		}
 	}
 	return serviceEnv, nil
+}
+
+// returns docker network name
+func (b *DockerBox) getNetworkName() string {
+	return "wercker-" + b.options.RunID
 }

--- a/docker/box.go
+++ b/docker/box.go
@@ -704,7 +704,7 @@ func (b *DockerBox) prepareSvcDockerEnvVar(env *util.Environment) ([]string, err
 				break
 			}
 			serviceEnv = append(serviceEnv, fmt.Sprintf("%s_NAME=/%s/%s", strings.ToUpper(serviceName), b.getContainerName(), serviceName))
-			lowestPort := math.MaxInt64
+			lowestPort := math.MaxInt32
 			var protLowestPort string
 			for k, _ := range container.Config.ExposedPorts {
 				s := strings.Split(string(k), "/")

--- a/docker/box.go
+++ b/docker/box.go
@@ -694,6 +694,7 @@ func (b *DockerBox) prepareSvcDockerEnvVar(env *util.Environment) ([]string, err
 		if containerID := service.GetID(); containerID != "" {
 			container, err := client.InspectContainer(containerID)
 			if err != nil {
+				b.logger.Error("Error while inspecting container", err)
 				return nil, err
 			}
 			ns := container.NetworkSettings

--- a/docker/box.go
+++ b/docker/box.go
@@ -505,6 +505,9 @@ func (b *DockerBox) Clean() error {
 				return err
 			}
 		}
+		b.logger.WithFields(util.LogFields{
+			"Name": dockerNetworkName,
+		}).Debugln("Removing docker network ", dockerNetworkName)
 		err = client.RemoveNetwork(dockerNetworkName)
 		if err != nil {
 			b.logger.Error("Error while removing docker network", err)
@@ -690,13 +693,16 @@ func (b *DockerBox) ExportImage(options *ExportImageOptions) error {
 func (b *DockerBox) createDockerNetwork(dockerNetworkName string) (*docker.Network, error) {
 	b.logger.Debugln("Creating docker network")
 	client := b.client
+	b.logger.WithFields(util.LogFields{
+		"Name": dockerNetworkName,
+	}).Debugln("Creating docker network :", dockerNetworkName)
 	return client.CreateNetwork(docker.CreateNetworkOptions{
 		Name:           dockerNetworkName,
 		CheckDuplicate: true,
 	})
 }
 
-// Prepares and return DockerEnvironment variables list created in case of docker links corresponding to each service.
+// Prepares and return DockerEnvironment variables list.
 // For each service In case of docker links, docker creates some environment variables and inject them to box container.
 // Since docker links is replaced by docker network, these environment variables needs to be created manually.
 // Below environment variables created and injected to box container.

--- a/docker/options.go
+++ b/docker/options.go
@@ -1,4 +1,4 @@
-//   Copyright 2016 Wercker Holding BV
+//   Copyright © 2016, 2018, Oracle and/or its affiliates.  All rights reserved.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/docker/options.go
+++ b/docker/options.go
@@ -37,6 +37,8 @@ type Options struct {
 	MemorySwap        int64
 	KernelMemory      int64
 	CleanupImage      bool
+	NetworkName       string
+	RemoveNetwork     bool
 }
 
 func guessAndUpdateDockerOptions(opts *Options, e *util.Environment) {
@@ -121,6 +123,8 @@ func NewOptions(c util.Settings, e *util.Environment) (*Options, error) {
 	dockerMemorySwap, _ := c.Int("docker-memory-swap")
 	dockerKernelMemory, _ := c.Int("docker-kernel-memory")
 	dockerCleanupImage, _ := c.Bool("docker-cleanup-image")
+	dockerNetworkName, _ := c.String("docker-network")
+	dockerRemoveNetwork, _ := c.Bool("docker-network-rm")
 
 	speculativeOptions := &Options{
 		Host:              dockerHost,
@@ -135,6 +139,8 @@ func NewOptions(c util.Settings, e *util.Environment) (*Options, error) {
 		MemorySwap:        int64(dockerMemorySwap) * 1024 * 1024,
 		KernelMemory:      int64(dockerKernelMemory) * 1024 * 1024,
 		CleanupImage:      dockerCleanupImage,
+		NetworkName:       dockerNetworkName,
+		RemoveNetwork:     dockerRemoveNetwork,
 	}
 
 	// We're going to try out a few settings and set DockerHost if

--- a/docker/options.go
+++ b/docker/options.go
@@ -38,7 +38,6 @@ type Options struct {
 	KernelMemory      int64
 	CleanupImage      bool
 	NetworkName       string
-	RemoveNetwork     bool
 }
 
 func guessAndUpdateDockerOptions(opts *Options, e *util.Environment) {
@@ -124,7 +123,6 @@ func NewOptions(c util.Settings, e *util.Environment) (*Options, error) {
 	dockerKernelMemory, _ := c.Int("docker-kernel-memory")
 	dockerCleanupImage, _ := c.Bool("docker-cleanup-image")
 	dockerNetworkName, _ := c.String("docker-network")
-	dockerRemoveNetwork, _ := c.Bool("docker-network-rm")
 
 	speculativeOptions := &Options{
 		Host:              dockerHost,
@@ -140,7 +138,6 @@ func NewOptions(c util.Settings, e *util.Environment) (*Options, error) {
 		KernelMemory:      int64(dockerKernelMemory) * 1024 * 1024,
 		CleanupImage:      dockerCleanupImage,
 		NetworkName:       dockerNetworkName,
-		RemoveNetwork:     dockerRemoveNetwork,
 	}
 
 	// We're going to try out a few settings and set DockerHost if

--- a/docker/service.go
+++ b/docker/service.go
@@ -106,7 +106,7 @@ func (b *InternalServiceBox) getContainerName() string {
 }
 
 // Run executes the service
-func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment, links []string) (*docker.Container, error) {
+func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment) (*docker.Container, error) {
 	e, err := core.EmitterFromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -174,10 +174,15 @@ func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment, lin
 		portsToBind = b.config.Ports
 	}
 
+	networkName := b.dockerOptions.NetworkName
+	if networkName == "" {
+		networkName = b.options.RunID
+	}
+
 	hostConfig := &docker.HostConfig{
 		DNS:          b.dockerOptions.DNS,
 		PortBindings: portBindings(portsToBind),
-		Links:        links,
+		NetworkMode:  networkName,
 	}
 
 	if len(binds) > 0 {
@@ -270,6 +275,11 @@ func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment, lin
 			})
 		}
 	}()
-
 	return container, nil
+}
+
+// service name
+func (b *InternalServiceBox) GetServiceName() string {
+	name := b.config.Name
+	return name
 }

--- a/docker/service.go
+++ b/docker/service.go
@@ -1,4 +1,4 @@
-//   Copyright 2016 Wercker Holding BV
+//   Copyright © 2016, 2018, Oracle and/or its affiliates.  All rights reserved.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -215,11 +215,20 @@ func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment) (*d
 		conf.MemorySwap = swap
 	}
 
+	endpointConfig := &docker.EndpointConfig{
+		Aliases: []string{b.GetServiceAlias()},
+	}
+	endpointConfigMap := make(map[string]*docker.EndpointConfig)
+	endpointConfigMap[networkName] = endpointConfig
+
 	container, err := client.CreateContainer(
 		docker.CreateContainerOptions{
 			Name:       b.getContainerName(),
 			Config:     conf,
 			HostConfig: hostConfig,
+			NetworkingConfig: &docker.NetworkingConfig{
+				EndpointsConfig: endpointConfigMap,
+			},
 		})
 
 	if err != nil {
@@ -278,8 +287,11 @@ func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment) (*d
 	return container, nil
 }
 
-// service name
-func (b *InternalServiceBox) GetServiceName() string {
+// GetServiceAlias returns service alias for the service.
+func (b *InternalServiceBox) GetServiceAlias() string {
 	name := b.config.Name
+	if name == "" {
+		name = b.ShortName
+	}
 	return name
 }

--- a/docker/service.go
+++ b/docker/service.go
@@ -174,10 +174,7 @@ func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment) (*d
 		portsToBind = b.config.Ports
 	}
 
-	networkName := b.dockerOptions.NetworkName
-	if networkName == "" {
-		networkName = b.options.RunID
-	}
+	networkName, _ := b.GetDockerNetworkName()
 
 	hostConfig := &docker.HostConfig{
 		DNS:          b.dockerOptions.DNS,

--- a/test-all.sh
+++ b/test-all.sh
@@ -129,9 +129,9 @@ testDockerNetworks () {
 }
 
 runTests() {
-  testDockerNetworks || return 1
-  #source $testsDir/docker-build/test.sh || return 1
-  #source $testsDir/docker-push-image/test.sh || return 1
+  
+  source $testsDir/docker-build/test.sh || return 1
+  source $testsDir/docker-push-image/test.sh || return 1
 
   export X_TEST_SERVICE_VOL_PATH=$testsDir/test-service-vol
   basicTest "service volume"    build "$testsDir/service-volume" --docker-local --enable-volumes  || return 1

--- a/test-all.sh
+++ b/test-all.sh
@@ -41,6 +41,7 @@ pullImages () {
   pullIfNeeded "alpine"
   pullIfNeeded "ubuntu"
   pullIfNeeded "golang"
+  pullIfNeeded "postgres:9.6"
 }
 
 basicTest() {
@@ -110,11 +111,27 @@ testScratchPush () {
   fi
 }
 
+testDockerNetworks () {
+  echo -n "testing docker-n-networks.."
+  testDir=$testsDir/docker-n-networks
+  logFile="${workingDir}/docker-n-networks.log"
+  
+  $wercker build "$testDir" --docker-local --working-dir "$workingDir" &> "$logFile"
+  if [ $? -eq 0 ]; then
+    echo "passed"
+    return 0
+  else
+      echo 'failed'
+      cat "$logFile"
+      docker images
+      return 1
+  fi
+}
 
 runTests() {
-
-  source $testsDir/docker-build/test.sh || return 1
-  source $testsDir/docker-push-image/test.sh || return 1
+  testDockerNetworks || return 1
+  #source $testsDir/docker-build/test.sh || return 1
+  #source $testsDir/docker-push-image/test.sh || return 1
 
   export X_TEST_SERVICE_VOL_PATH=$testsDir/test-service-vol
   basicTest "service volume"    build "$testsDir/service-volume" --docker-local --enable-volumes  || return 1
@@ -152,6 +169,7 @@ runTests() {
 
   testDirectMount || return 1
   testScratchPush || return 1
+  testDockerNetworks || return 1
 
   # test runs locally but not in wercker build container
   #basicTest "shellstep" build --docker-local --enable-dev-steps "$testsDir/shellstep" || return 1

--- a/tests/projects/docker-n-networks/wercker.yml
+++ b/tests/projects/docker-n-networks/wercker.yml
@@ -1,0 +1,87 @@
+box: golang 
+services:
+- name: postgres
+  id: postgres
+  tag: 9.6
+  env:
+    POSTGRES_PASSWORD: test
+    POSTGRES_USER: test
+    
+build:
+  steps:
+    - wercker/golint
+    - script:
+       name: go build
+       code: |
+
+         ping -c 2 postgres
+
+         if [ -z "$POSTGRES_PORT_5432_TCP_ADDR" ]
+         then
+           exit 2
+         fi
+         
+         if [ -z "$POSTGRES_PORT_5432_TCP_PORT" && ${POSTGRES_PORT_5432_TCP_PORT} == "5432"]
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_PORT_5432_TCP_PROTO" && ${POSTGRES_PORT_5432_TCP_PROTO} == "tcp"]
+         then
+           exit 2
+         fi
+         
+         if [ -z "$POSTGRES_PORT_5432_TCP" && ${POSTGRES_PORT_5432_TCP} == "$POSTGRES_PORT_5432_TCP_PROTO://$POSTGRES_PORT_5432_TCP_ADDR:$POSTGRES_PORT_5432_TCP_PORT" ]
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_PORT" && ${POSTGRES_PORT} == "$POSTGRES_PORT_5432_TCP_PROTO://$POSTGRES_PORT_5432_TCP_ADDR:$POSTGRES_PORT_5432_TCP_PORT" ]
+         then
+           exit 2
+         fi
+         
+         if [ -z "$POSTGRES_NAME" ]
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_ENV_PGDATA" ]
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_ENV_PATH" ]
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_ENV_LANG" ]
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_ENV_PG_VERSION" ]
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_ENV_GOSU_VERSION" ]
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_ENV_PG_MAJOR" && ${POSTGRES_ENV_PG_MAJOR} == "9.6" ]
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_ENV_POSTGRES_USER" && ${POSTGRES_ENV_POSTGRES_USER} == "test" ]
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_ENV_POSTGRES_PASSWORD" && ${POSTGRES_ENV_POSTGRES_PASSWORD} == "test" ]
+         then
+           exit 2
+         fi


### PR DESCRIPTION
Wercker cli use docker links for communication. It has been changed to use custom bridge network.

Proposal and design is described in https://confluence.oraclecorp.com/confluence/display/WRKR/Docker+Networks