### PR TITLE
Fixes #1959, #1960, #1961 - Changes for robust error handling and reporting in docker-push

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+- Changes for robust error handling and reporting in docker-push (#387)
+
 ## v1.0.1201 (2018-04-16)
 
 - Update azure client to allow docker-push in all regions (#381)

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -675,7 +675,12 @@ func (p *Runner) RunStep(shared *RunnerShared, step core.Step, order int) (*Step
 		}
 	}
 
-	step.InitEnv(shared.pipeline.Env())
+	err := step.InitEnv(shared.pipeline.Env())
+	if err != nil {
+		sr.Message = err.Error()
+		return sr, fmt.Errorf("Step initEnv failed with error message: %s", err.Error())
+	}
+
 	p.logger.Debugln("Step Environment")
 	for _, pair := range step.Env().Ordered() {
 		p.logger.Debugln(" ", pair[0], pair[1])

--- a/cmd/runner_test.go
+++ b/cmd/runner_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/wercker/wercker/core"
+	"github.com/wercker/wercker/util"
+	"golang.org/x/net/context"
+)
+
+const initEnvErrorMessage = "InitEnv failed"
+
+type RunnerSuite struct {
+	*util.TestSuite
+}
+
+func TestRunnerSuite(t *testing.T) {
+	suiteTester := &RunnerSuite{&util.TestSuite{}}
+	suite.Run(t, suiteTester)
+}
+
+//MockStep mocks Step
+type MockStep struct {
+	*core.BaseStep
+}
+
+// Mock methods not implemented by BaseStep
+func (s *MockStep) CollectArtifact(string) (*core.Artifact, error) {
+	return nil, nil
+}
+
+func (s *MockStep) CollectFile(string, string, string, io.Writer) error {
+	return nil
+}
+
+func (s *MockStep) Execute(context.Context, *core.Session) (int, error) {
+	return 0, nil
+}
+
+func (s *MockStep) Fetch() (string, error) {
+	return "", nil
+}
+
+func (s *MockStep) ReportPath(...string) string {
+	return ""
+}
+
+func (s *MockStep) ShouldSyncEnv() bool {
+	return false
+}
+
+func (s *MockStep) InitEnv(*util.Environment) error {
+	return errors.New(initEnvErrorMessage)
+}
+
+//MockPipeline mocks Pipeline
+type MockPipeline struct {
+	*core.BasePipeline
+}
+
+//Mock methods not implemented by BasePipeLine
+func (s *MockPipeline) CollectArtifact(string) (*core.Artifact, error) {
+	return nil, nil
+}
+
+func (s *MockPipeline) CollectCache(string) error {
+	return nil
+}
+
+func (s *MockPipeline) DockerMessage() string {
+	return ""
+}
+
+func (s *MockPipeline) DockerRepo() string {
+	return ""
+}
+
+func (s *MockPipeline) DockerTag() string {
+	return ""
+}
+
+func (s *MockPipeline) InitEnv(*util.Environment) {
+
+}
+
+func (s *MockPipeline) LocalSymlink() {
+
+}
+
+func (s *MockPipeline) Env() *util.Environment {
+	return nil
+}
+
+//TestRunnerStepFailedOnInitEnvError tests the scenario when a step in the pipleine
+// will fail when an error occurs in initEnv() in step
+func (s *RunnerSuite) TestRunnerStepFailedOnInitEnvError() {
+	mockPipeline := &MockPipeline{}
+	shared := &RunnerShared{pipeline: mockPipeline}
+	step := &MockStep{}
+	runner := &Runner{}
+	runner.emitter = core.NewNormalizedEmitter()
+
+	sr, err := runner.RunStep(shared, step, 1)
+	s.Error(err)
+	fmt.Println(err.Error())
+	s.Contains(err.Error(), "Step initEnv failed with error message")
+	s.Equal(sr.Message, initEnvErrorMessage)
+	s.NotEqual(sr.Message, 0)
+}

--- a/cmd/runner_test.go
+++ b/cmd/runner_test.go
@@ -109,5 +109,5 @@ func (s *RunnerSuite) TestRunnerStepFailedOnInitEnvError() {
 	fmt.Println(err.Error())
 	s.Contains(err.Error(), "Step initEnv failed with error message")
 	s.Equal(sr.Message, initEnvErrorMessage)
-	s.NotEqual(sr.Message, 0)
+	s.NotEqual(sr.ExitCode, 0)
 }

--- a/core/step.go
+++ b/core/step.go
@@ -95,7 +95,7 @@ type Step interface {
 	// Actual methods
 	Fetch() (string, error)
 
-	InitEnv(*util.Environment)
+	InitEnv(*util.Environment) error
 	Execute(context.Context, *Session) (int, error)
 	CollectFile(string, string, string, io.Writer) error
 	CollectArtifact(string) (*Artifact, error)
@@ -486,7 +486,7 @@ func (s *ExternalStep) CollectArtifact(containerID string) (*Artifact, error) {
 }
 
 // InitEnv sets up the internal environment for the Step.
-func (s *ExternalStep) InitEnv(env *util.Environment) {
+func (s *ExternalStep) InitEnv(env *util.Environment) error {
 	a := [][]string{
 		[]string{"WERCKER_STEP_ROOT", s.GuestPath()},
 		[]string{"WERCKER_STEP_ID", s.safeID},
@@ -521,6 +521,8 @@ func (s *ExternalStep) InitEnv(env *util.Environment) {
 		key = strings.ToUpper(key)
 		s.Env().Add(key, value)
 	}
+
+	return nil
 }
 
 // CachedName returns a name suitable for caching

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -753,7 +753,7 @@ func InferRegistryAndRepository(repository string, registry string, pipelineOpti
 	}
 
 	if len(strings.TrimSpace(inferredRegistry)) != 0 {
-		regsitryURLFromStepConfig, err := url.ParseRequestURI(inferredRegistry)
+		registryURLFromStepConfig, err := url.ParseRequestURI(inferredRegistry)
 		if err != nil {
 			_logger.Errorln("Invalid registry url specified: ", err.Error)
 			if registryInferredFromRepository != "" {
@@ -765,7 +765,7 @@ func InferRegistryAndRepository(repository string, registry string, pipelineOpti
 			}
 
 		} else {
-			domainFromRegistryURL := regsitryURLFromStepConfig.Host
+			domainFromRegistryURL := registryURLFromStepConfig.Host
 			if len(strings.TrimSpace(domainFromRepository)) != 0 && domainFromRepository != "docker.io" {
 				if domainFromRegistryURL != domainFromRepository {
 					_logger.Infoln("Different registry hosts specified in repository: " + domainFromRepository + " and registry: " + domainFromRegistryURL)

--- a/docker/docker_build.go
+++ b/docker/docker_build.go
@@ -153,8 +153,9 @@ func (s *DockerBuildStep) configure(env *util.Environment) {
 }
 
 // InitEnv parses our data into our config
-func (s *DockerBuildStep) InitEnv(env *util.Environment) {
+func (s *DockerBuildStep) InitEnv(env *util.Environment) error {
 	s.configure(env)
+	return nil
 }
 
 // Fetch NOP

--- a/docker/publish_step.go
+++ b/docker/publish_step.go
@@ -77,7 +77,7 @@ func NewPublishStep(stepConfig *core.StepConfig, options *core.PipelineOptions, 
 }
 
 // InitEnv parses our data into our config
-func (s *PublishStep) InitEnv(env *util.Environment) {
+func (s *PublishStep) InitEnv(env *util.Environment) error {
 	if owner, ok := s.data["owner"]; ok {
 		s.user = env.Interpolate(owner)
 	}
@@ -90,6 +90,7 @@ func (s *PublishStep) InitEnv(env *util.Environment) {
 	if path, ok := s.data["path"]; ok {
 		s.pathInContainer = pathInContainer(path)
 	}
+	return nil
 }
 
 // Fetch NOP

--- a/docker/shellstep.go
+++ b/docker/shellstep.go
@@ -68,20 +68,23 @@ func NewShellStep(stepConfig *core.StepConfig, options *core.PipelineOptions, do
 }
 
 // InitEnv parses our data into our config
-func (s *ShellStep) InitEnv(env *util.Environment) {
+func (s *ShellStep) InitEnv(env *util.Environment) error {
 	if code, ok := s.data["code"]; ok {
 		s.Code = code
 	}
-	if cmd, ok := s.data["cmd"]; ok {
+	if cmd, ok := s.data["cmd"]; ok && cmd != "" {
 		parts, err := shlex.Split(cmd)
 		if err == nil {
 			s.Cmd = parts
+		} else {
+			return fmt.Errorf("%s is an invalid value for cmd, parsing error: %s", cmd, err.Error())
 		}
 	} else {
 		cmd, _ := shlex.Split(DefaultDockerCommand)
 		s.Cmd = cmd
 	}
 	s.env = env
+	return nil
 }
 
 // Fetch NOP

--- a/docker/store.go
+++ b/docker/store.go
@@ -71,8 +71,9 @@ func NewStoreContainerStep(stepConfig *core.StepConfig, options *core.PipelineOp
 }
 
 // InitEnv preps our env
-func (s *StoreContainerStep) InitEnv(env *util.Environment) {
+func (s *StoreContainerStep) InitEnv(env *util.Environment) error {
 	// NOP
+	return nil
 }
 
 // Fetch NOP

--- a/docker/watchstep.go
+++ b/docker/watchstep.go
@@ -80,17 +80,18 @@ func NewWatchStep(stepConfig *core.StepConfig, options *core.PipelineOptions, do
 }
 
 // InitEnv parses our data into our config
-func (s *WatchStep) InitEnv(env *util.Environment) {
+func (s *WatchStep) InitEnv(env *util.Environment) error {
 	if code, ok := s.data["code"]; ok {
 		s.Code = code
 	}
-	if reload, ok := s.data["reload"]; ok {
+	if reload, ok := s.data["reload"]; ok && reload != "" {
 		if v, err := strconv.ParseBool(reload); err == nil {
 			s.reload = v
 		} else {
-			s.logger.Panic(err)
+			return fmt.Errorf("%s is an invalid value for reload, error while validating: %s", reload, err.Error())
 		}
 	}
+	return nil
 }
 
 // Fetch NOP

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2054,10 +2054,12 @@
 			"revisionTime": "2017-07-07T00:42:18Z"
 		},
 		{
-			"checksumSHA1": "hwuhOL78FeNle4mOksY8Bx+5j3k=",
+			"checksumSHA1": "stOFtWGk92Hw68KPx6VSwGyhH/s=",
 			"path": "github.com/wercker/docker-check-access",
-			"revision": "6de3890fc137c624884041d0af695128cb6db976",
-			"revisionTime": "2018-04-10T06:27:42Z"
+			"revision": "23f3946540ed35e02e3a56cd88f4b2afd3781244",
+			"revisionTime": "2018-04-13T04:28:32Z",
+			"version": "=issue-1960",
+			"versionExact": "issue-1960"
 		},
 		{
 			"checksumSHA1": "rpIHxVmXHbM31S0S/2qE1kAvzfw=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2078,10 +2078,12 @@
 			"revisionTime": "2017-07-07T00:42:18Z"
 		},
 		{
-			"checksumSHA1": "wPQ3c6Cb/QHmKLwAID2fIrCPsM0=",
+			"checksumSHA1": "NxtneY3rSGg/2OVq6usKImalr2E=",
 			"path": "github.com/wercker/docker-check-access",
-			"revision": "836cd5a55a65df341195171b26f4f8875a66cd88",
-			"revisionTime": "2018-04-16T04:57:47Z"
+			"revision": "d5855e180d779364298d772b3ed2c728858dc381",
+			"revisionTime": "2018-04-16T07:57:50Z",
+			"version": "=issue-1960",
+			"versionExact": "issue-1960"
 		},
 		{
 			"checksumSHA1": "rpIHxVmXHbM31S0S/2qE1kAvzfw=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2054,12 +2054,10 @@
 			"revisionTime": "2017-07-07T00:42:18Z"
 		},
 		{
-			"checksumSHA1": "stOFtWGk92Hw68KPx6VSwGyhH/s=",
+			"checksumSHA1": "wPQ3c6Cb/QHmKLwAID2fIrCPsM0=",
 			"path": "github.com/wercker/docker-check-access",
-			"revision": "23f3946540ed35e02e3a56cd88f4b2afd3781244",
-			"revisionTime": "2018-04-13T04:28:32Z",
-			"version": "=issue-1960",
-			"versionExact": "issue-1960"
+			"revision": "836cd5a55a65df341195171b26f4f8875a66cd88",
+			"revisionTime": "2018-04-16T04:57:47Z"
 		},
 		{
 			"checksumSHA1": "rpIHxVmXHbM31S0S/2qE1kAvzfw=",


### PR DESCRIPTION
Fixes [wercker/backlog#1959](https://github.com/wercker/backlog/issues/1959), [wercker/backlog#1960](https://github.com/wercker/backlog/issues/1960), [wercker/backlog#1961 ](https://github.com/wercker/backlog/issues/1961)

- Change step.InitEnv to be able to return an error in case of any initialization errors
- Added runner_test.go as unit test for InitEnv change
- Removed log.panic from few places in InitEnv and return the error instead
- Fixed docker.InferRegistryAndRepository docs, additional error handing and better error messages while evaluating registry and repository
- Enhanced error message from docker.tagAndPush for errors originating from docker daemon while doing a push
- Added test case for invalid registry and repository checking for InferrEgistryAndRepository
- vendor.json points to [issue-1960](https://github.com/wercker/docker-check-access/tree/issue-1960) branch of docker-check-access which contains changes mentioned in PR [wercker/docker-check-access#PR9](https://github.com/wercker/docker-check-access/pull/9). Will point back to master after merging