### PR TITLE
Replace hyphen with underscore for services in env

### DIFF
--- a/docker/box.go
+++ b/docker/box.go
@@ -716,7 +716,7 @@ func (b *DockerBox) prepareSvcDockerEnvVar(env *util.Environment) ([]string, err
 	serviceEnv := []string{}
 	client := b.client
 	for _, service := range b.services {
-		serviceName := service.GetServiceAlias()
+		serviceName := strings.Replace(service.GetServiceAlias(), "-", "_", -1)
 		if containerID := service.GetID(); containerID != "" {
 			container, err := client.InspectContainer(containerID)
 			if err != nil {


### PR DESCRIPTION
Mentioned this in your slack channel.

When docker injects the environment variables for linked containers, it replaces hyphens with underscores. This is because hyphens are invalid environment variable characters in most shells.

Wercker no longer appears to replicate this logic. There is a workaround to resolve the issue with a change to a project's `wercker.yml`:
```
services:
  - some-namespace/some-service
```

... replace with ...

```
services:
  - id: some-namespace/some-service
    name: some_service
```

This PR does the same by replacing hyphens with underscores in the service alias. It's not great but it at least demonstrates the fix.