### PR TITLE
Convert calls to InspectImage to use the official docker client

### DIFF
--- a/cmd/builder.go
+++ b/cmd/builder.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/codegangsta/cli"
-	"github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/wercker/wercker/core"
 	"github.com/wercker/wercker/docker"
 	"github.com/wercker/wercker/util"
@@ -89,7 +89,7 @@ func (b *DockerBuilder) getOptions(env *util.Environment, config *core.BoxConfig
 }
 
 // Build the image and commit it so we can use it as a service
-func (b *DockerBuilder) Build(ctx context.Context, env *util.Environment, config *core.BoxConfig) (*dockerlocal.DockerBox, *docker.Image, error) {
+func (b *DockerBuilder) Build(ctx context.Context, env *util.Environment, config *core.BoxConfig) (*dockerlocal.DockerBox, *types.ImageInspect, error) {
 	newOptions, err := b.getOptions(env, config)
 
 	if err != nil {
@@ -114,10 +114,10 @@ func (b *DockerBuilder) Build(ctx context.Context, env *util.Environment, config
 		return nil, nil, err
 	}
 
-	client, err := dockerlocal.NewDockerClient(&newDockerOptions)
-	image, err := client.InspectImage(box.Name)
+	client, err := dockerlocal.NewOfficialDockerClient(&newDockerOptions)
+	image, _, err := client.ImageInspectWithRaw(ctx, box.Name)
 	if err != nil {
 		return nil, nil, err
 	}
-	return box, image, nil
+	return box, &image, nil
 }

--- a/core/box.go
+++ b/core/box.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"github.com/docker/docker/api/types"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/wercker/wercker/util"
 	"golang.org/x/net/context"
@@ -34,7 +35,7 @@ type Box interface {
 	Commit(string, string, string, bool) (*docker.Image, error)
 	Restart() (*docker.Container, error)
 	AddService(ServiceBox)
-	Fetch(context.Context, *util.Environment) (*docker.Image, error)
+	Fetch(context.Context, *util.Environment) (*types.ImageInspect, error)
 	Run(context.Context, *util.Environment) (*docker.Container, error)
 	RecoverInteractive(string, Pipeline, Step) error
 }

--- a/core/service.go
+++ b/core/service.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"github.com/docker/docker/api/types"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/wercker/wercker/util"
 	"golang.org/x/net/context"
@@ -23,7 +24,7 @@ import (
 // ServiceBox interface to services
 type ServiceBox interface {
 	Run(context.Context, *util.Environment, []string) (*docker.Container, error)
-	Fetch(ctx context.Context, env *util.Environment) (*docker.Image, error)
+	Fetch(ctx context.Context, env *util.Environment) (*types.ImageInspect, error)
 	Link() string
 	GetID() string
 	GetName() string

--- a/docker/service.go
+++ b/docker/service.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/docker/docker/api/types"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/google/shlex"
 	"github.com/wercker/wercker/core"
@@ -29,12 +30,12 @@ import (
 // Builder interface to create an image based on a service config
 // kinda needed so we can break a bunch of circular dependencies with cmd
 type Builder interface {
-	Build(context.Context, *util.Environment, *core.BoxConfig) (*DockerBox, *docker.Image, error)
+	Build(context.Context, *util.Environment, *core.BoxConfig) (*DockerBox, *types.ImageInspect, error)
 }
 
 type nilBuilder struct{}
 
-func (b *nilBuilder) Build(ctx context.Context, env *util.Environment, config *core.BoxConfig) (*DockerBox, *docker.Image, error) {
+func (b *nilBuilder) Build(ctx context.Context, env *util.Environment, config *core.BoxConfig) (*DockerBox, *types.ImageInspect, error) {
 	return nil, nil, nil
 }
 
@@ -68,7 +69,7 @@ func NewExternalServiceBox(boxConfig *core.BoxConfig, options *core.PipelineOpti
 
 // Fetch the image representation of an ExternalServiceBox
 // this means running the ExternalServiceBox and comitting the image
-func (s *ExternalServiceBox) Fetch(ctx context.Context, env *util.Environment) (*docker.Image, error) {
+func (s *ExternalServiceBox) Fetch(ctx context.Context, env *util.Environment) (*types.ImageInspect, error) {
 	originalShortName := s.externalConfig.ID
 	box, image, err := s.builder.Build(ctx, env, s.externalConfig)
 	if err != nil {


### PR DESCRIPTION
This PR changes the three places that use the `InspectImage` function in the fsouza docker client to to use the `ImageInspectWithRaw` function in the official docker client.