### PR TITLE
Dockerfile integration test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+- Docker file integration (#415)
+
 ## v1.0.1226 (2018-05-11)
 
 - Reverted Cosmetic changes for docker file integration (#407)

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 - Docker file integration (#415)
 
+## v1.0.1230 (2018-05-15)
+
+- Support for publishing private steps (#409)
+
 ## v1.0.1226 (2018-05-11)
 
 - Reverted Cosmetic changes for docker file integration (#407)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -49,6 +49,7 @@ var (
 		cli.IntFlag{Name: "docker-memory-reservation", Usage: "Set docker user memory soft limit in MB NOTIMPLEMENTED", Hidden: true},
 		cli.IntFlag{Name: "docker-kernel-memory", Usage: "Set docker kernel memory limit in MB NOTIMPLEMENTED", Hidden: true},
 		cli.BoolFlag{Name: "docker-cleanup-image", Usage: "Remove image from the Docker when finished pushing them", Hidden: true},
+		cli.StringFlag{Name: "docker-network", Value: "", Usage: "Docker network name.", Hidden: true},
 	}
 
 	// These flags control where we store local files

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1160,6 +1160,7 @@ func executePipeline(cmdCtx context.Context, options *core.PipelineOptions, dock
 	stepCounter := &util.Counter{Current: 3}
 	checkpoint := false
 	for _, step := range pipeline.Steps() {
+		defer step.Clean()
 		// we always want to run the wercker-init step to provide some functions
 		if !checkpoint && stepCounter.Current > 3 {
 			if options.EnableDevSteps && options.Checkpoint != "" {

--- a/core/options.go
+++ b/core/options.go
@@ -1,4 +1,4 @@
-//   Copyright 2016 Wercker Holding BV
+//   Copyright © 2016, 2018, Oracle and/or its affiliates.  All rights reserved.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/core/options.go
+++ b/core/options.go
@@ -301,9 +301,10 @@ type PipelineOptions struct {
 	//               places by BasePipeline
 	HostEnv *util.Environment
 
-	RunID        string
-	DeployTarget string
-	Pipeline     string
+	RunID             string
+	DeployTarget      string
+	Pipeline          string
+	DockerNetworkName string
 
 	ApplicationID            string
 	ApplicationName          string

--- a/core/service.go
+++ b/core/service.go
@@ -22,7 +22,7 @@ import (
 
 // ServiceBox interface to services
 type ServiceBox interface {
-	Run(context.Context, *util.Environment) (*docker.Container, error)
+	Run(context.Context, *util.Environment, []string) (*docker.Container, error)
 	Fetch(ctx context.Context, env *util.Environment) (*docker.Image, error)
 	GetID() string
 	GetName() string

--- a/core/service.go
+++ b/core/service.go
@@ -1,4 +1,4 @@
-//   Copyright 2016 Wercker Holding BV
+//   Copyright © 2016,2018, Oracle and/or its affiliates.  All rights reserved.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@ import (
 
 // ServiceBox interface to services
 type ServiceBox interface {
-	Run(context.Context, *util.Environment, []string) (*docker.Container, error)
+	Run(context.Context, *util.Environment) (*docker.Container, error)
 	Fetch(ctx context.Context, env *util.Environment) (*docker.Image, error)
-	Link() string
 	GetID() string
 	GetName() string
+	GetServiceAlias() string
 }

--- a/core/step.go
+++ b/core/step.go
@@ -101,6 +101,7 @@ type Step interface {
 	CollectArtifact(context.Context, string) (*Artifact, error)
 	// TODO(termie): don't think this needs to be universal
 	ReportPath(...string) string
+	Clean()
 }
 
 // BaseStepOptions are exported fields so that we can make a BaseStep from
@@ -187,6 +188,10 @@ func (s *BaseStep) Version() string {
 // Version getter
 func (s *BaseStep) Checkpoint() string {
 	return s.checkpoint
+}
+
+func (s *BaseStep) Clean() {
+
 }
 
 // ExternalStep is the holder of the Step methods.

--- a/docker/box.go
+++ b/docker/box.go
@@ -18,8 +18,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/fsouza/go-dockerclient"
@@ -52,6 +54,7 @@ type DockerBox struct {
 	entrypoint      string
 	image           *docker.Image
 	volumes         []string
+	dockerEnvVar    []string
 }
 
 // NewDockerBox from a name and other references
@@ -59,7 +62,7 @@ func NewDockerBox(boxConfig *core.BoxConfig, options *core.PipelineOptions, dock
 	name := boxConfig.ID
 
 	if strings.Contains(name, "@") {
-		return nil, fmt.Errorf("Invalid box name, '@' is not allowed in docker repositories.")
+		return nil, fmt.Errorf("Invalid box name, '@' is not allowed in docker repositories")
 	}
 
 	parts := strings.Split(name, ":")
@@ -188,17 +191,24 @@ func (b *DockerBox) binds(env *util.Environment) ([]string, error) {
 
 // RunServices runs the services associated with this box
 func (b *DockerBox) RunServices(ctx context.Context, env *util.Environment) error {
-
+	linkedEnvVars := []string{}
 	// TODO(termie): terrible hack, sorry world
 	ctxWithServiceCount := context.WithValue(ctx, "ServiceCount", len(b.services))
 
 	for _, service := range b.services {
 		b.logger.Debugln("Startinq service:", service.GetName())
-		_, err := service.Run(ctxWithServiceCount, env)
+		_, err := service.Run(ctxWithServiceCount, env, linkedEnvVars)
 		if err != nil {
 			return err
 		}
+		svcEnvVar, err := b.prepareSvcDockerEnvVar(service, env)
+		if err != nil {
+			return err
+		}
+		linkedEnvVars = append(linkedEnvVars, svcEnvVar...)
 	}
+	b.dockerEnvVar = linkedEnvVars
+	b.logger.Debugln(b.dockerEnvVar)
 	return nil
 }
 
@@ -331,10 +341,6 @@ func (b *DockerBox) Run(ctx context.Context, env *util.Environment) (*docker.Con
 	if err != nil {
 		return nil, err
 	}
-	dockerEnvVar, err := b.prepareSvcDockerEnvVar(env)
-	if err != nil {
-		return nil, err
-	}
 	b.logger.Debugln("Starting base box:", b.Name)
 
 	// TODO(termie): maybe move the container manipulation outside of here?
@@ -342,7 +348,7 @@ func (b *DockerBox) Run(ctx context.Context, env *util.Environment) (*docker.Con
 
 	// Import the environment
 	myEnv := dockerEnv(b.config.Env, env)
-	myEnv = append(myEnv, dockerEnvVar...)
+	myEnv = append(myEnv, b.dockerEnvVar...)
 
 	var entrypoint []string
 	if b.entrypoint != "" {
@@ -648,4 +654,61 @@ func (b *DockerBox) ExportImage(options *ExportImageOptions) error {
 	client := b.client
 
 	return client.ExportImage(exportImageOptions)
+}
+
+// Prepares and return DockerEnvironment variables list.
+// For each service In case of docker links, docker creates some environment variables and inject them to box container.
+// Since docker links is replaced by docker network, these environment variables needs to be created manually.
+// Below environment variables created and injected to box container.
+// 01) <container name>_PORT_<port>_<protocol>_ADDR  - variable contains the IP Address.
+// 02) <container name>_PORT_<port>_<protocol>_PORT - variable contains just the port number.
+// 03) <container name>_PORT_<port>_<protocol>_PROTO - variable contains just the protocol.
+// 04) <container name>_ENV_<name> - Docker also exposes each Docker originated environment variable from the source container as an environment variable in the target.
+// 05) <container name>_PORT - variable contains the URL of the source container’s first exposed port. The ‘first’ port is defined as the exposed port with the lowest number.
+// 06) <container name>_NAME - variable is set for each service specified in wercker.yml.
+func (b *DockerBox) prepareSvcDockerEnvVar(service core.ServiceBox, env *util.Environment) ([]string, error) {
+	serviceEnv := []string{}
+	client := b.client
+	serviceName := strings.Replace(service.GetServiceAlias(), "-", "_", -1)
+	if containerID := service.GetID(); containerID != "" {
+		container, err := client.InspectContainer(containerID)
+		if err != nil {
+			b.logger.Error("Error while inspecting container", err)
+			return nil, err
+		}
+		ns := container.NetworkSettings
+		var serviceIPAddress string
+		for _, v := range ns.Networks {
+			serviceIPAddress = v.IPAddress
+			break
+		}
+		serviceEnv = append(serviceEnv, fmt.Sprintf("%s_NAME=/%s/%s", strings.ToUpper(serviceName), b.getContainerName(), serviceName))
+		lowestPort := math.MaxInt32
+		var protLowestPort string
+		for k := range container.Config.ExposedPorts {
+			exposedPort := strings.Split(string(k), "/") //exposedPort[0]=portNum and exposedPort[1]=protocal(tcp/udp)
+			x, err := strconv.Atoi(exposedPort[0])
+			if err != nil {
+				b.logger.Error("Unable to convert string port to integer", err)
+				return nil, err
+			}
+			if lowestPort > x {
+				lowestPort = x
+				protLowestPort = exposedPort[1]
+			}
+			dockerEnvPrefix := fmt.Sprintf("%s_PORT_%s_%s", strings.ToUpper(serviceName), exposedPort[0], strings.ToUpper(exposedPort[1]))
+			serviceEnv = append(serviceEnv, fmt.Sprintf("%s=%s://%s:%s", dockerEnvPrefix, exposedPort[1], serviceIPAddress, exposedPort[0]))
+			serviceEnv = append(serviceEnv, fmt.Sprintf("%s_ADDR=%s", dockerEnvPrefix, serviceIPAddress))
+			serviceEnv = append(serviceEnv, fmt.Sprintf("%s_PORT=%s", dockerEnvPrefix, exposedPort[0]))
+			serviceEnv = append(serviceEnv, fmt.Sprintf("%s_PROTO=%s", dockerEnvPrefix, exposedPort[1]))
+		}
+		if protLowestPort != "" {
+			serviceEnv = append(serviceEnv, fmt.Sprintf("%s_PORT=%s://%s:%s", strings.ToUpper(serviceName), protLowestPort, serviceIPAddress, strconv.Itoa(lowestPort)))
+		}
+		for _, envVar := range container.Config.Env {
+			serviceEnv = append(serviceEnv, fmt.Sprintf("%s_ENV_%s", strings.ToUpper(serviceName), envVar))
+		}
+	}
+	b.logger.Debug("Exposed Service Evnironment variables", serviceEnv)
+	return serviceEnv, nil
 }

--- a/docker/box.go
+++ b/docker/box.go
@@ -715,7 +715,7 @@ func (b *DockerBox) prepareSvcDockerEnvVar(service core.ServiceBox, env *util.En
 	return serviceEnv, nil
 }
 
-// Returns true if envVar exist in envVaList.
+// Returns true if envVar exist in envVarList.
 func contains(evnVarList []string, envVar string) bool {
 	for _, tmpVar := range evnVarList {
 		if tmpVar == envVar {

--- a/docker/box.go
+++ b/docker/box.go
@@ -119,25 +119,6 @@ func NewDockerBox(boxConfig *core.BoxConfig, options *core.PipelineOptions, dock
 	}, nil
 }
 
-func (b *DockerBox) links() []string {
-	serviceLinks := []string{}
-
-	for _, service := range b.services {
-		serviceLinks = append(serviceLinks, service.Link())
-	}
-	b.logger.Debugln("Creating links:", serviceLinks)
-	return serviceLinks
-}
-
-// Link gives us the parameter to Docker to link to this box
-func (b *DockerBox) Link() string {
-	name := b.config.Name
-	if name == "" {
-		name = b.ShortName
-	}
-	return fmt.Sprintf("%s:%s", b.container.Name, name)
-}
-
 // GetName gets the box name
 func (b *DockerBox) GetName() string {
 	return b.Name
@@ -207,18 +188,16 @@ func (b *DockerBox) binds(env *util.Environment) ([]string, error) {
 
 // RunServices runs the services associated with this box
 func (b *DockerBox) RunServices(ctx context.Context, env *util.Environment) error {
-	links := []string{}
 
 	// TODO(termie): terrible hack, sorry world
 	ctxWithServiceCount := context.WithValue(ctx, "ServiceCount", len(b.services))
 
 	for _, service := range b.services {
 		b.logger.Debugln("Startinq service:", service.GetName())
-		_, err := service.Run(ctxWithServiceCount, env, links)
+		_, err := service.Run(ctxWithServiceCount, env)
 		if err != nil {
 			return err
 		}
-		links = append(links, service.Link())
 	}
 	return nil
 }
@@ -344,7 +323,15 @@ func (b *DockerBox) getContainerName() string {
 
 // Run creates the container and runs it.
 func (b *DockerBox) Run(ctx context.Context, env *util.Environment) (*docker.Container, error) {
-	err := b.RunServices(ctx, env)
+	dockerNetworkName, err := b.GetDockerNetworkName()
+	if err != nil {
+		return nil, err
+	}
+	err = b.RunServices(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+	dockerEnvVar, err := b.prepareSvcDockerEnvVar(env)
 	if err != nil {
 		return nil, err
 	}
@@ -355,6 +342,7 @@ func (b *DockerBox) Run(ctx context.Context, env *util.Environment) (*docker.Con
 
 	// Import the environment
 	myEnv := dockerEnv(b.config.Env, env)
+	myEnv = append(myEnv, dockerEnvVar...)
 
 	var entrypoint []string
 	if b.entrypoint != "" {
@@ -389,9 +377,9 @@ func (b *DockerBox) Run(ctx context.Context, env *util.Environment) (*docker.Con
 
 	hostConfig := &docker.HostConfig{
 		Binds:        binds,
-		Links:        b.links(),
 		PortBindings: portBindings(portsToBind),
 		DNS:          b.dockerOptions.DNS,
+		NetworkMode:  dockerNetworkName,
 	}
 
 	conf := &docker.Config{
@@ -449,6 +437,7 @@ func (b *DockerBox) Run(ctx context.Context, env *util.Environment) (*docker.Con
 
 // Clean up the containers
 func (b *DockerBox) Clean() error {
+	defer b.CleanDockerNetwork()
 	containers := []string{}
 	if b.container != nil {
 		containers = append(containers, b.container.ID)

--- a/docker/docker_kill.go
+++ b/docker/docker_kill.go
@@ -1,0 +1,126 @@
+/* Copyright © 2018, Oracle and/or its affiliates. All rights reserved. */
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+package dockerlocal
+
+import (
+	"fmt"
+	"io"
+
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/pborman/uuid"
+	"github.com/wercker/wercker/core"
+	"github.com/wercker/wercker/util"
+	"golang.org/x/net/context"
+)
+
+// DockerKillStep needs to implemenet IStep
+type DockerKillStep struct {
+	*core.BaseStep
+	logger        *util.LogEntry
+	options       *core.PipelineOptions
+	dockerOptions *Options
+	data          map[string]string
+	containerName string
+}
+
+// NewDockerKillStep is a special step for killing and removing container.
+func NewDockerKillStep(stepConfig *core.StepConfig, options *core.PipelineOptions, dockerOptions *Options) (*DockerKillStep, error) {
+	name := "docker-kill"
+	displayName := "docker kill"
+	if stepConfig.Name == "" {
+		err := fmt.Errorf("\"name\" is a required field")
+		return nil, err
+	}
+	// Add a random number to the name to prevent collisions on disk
+	stepSafeID := fmt.Sprintf("%s-%s", name, uuid.NewRandom().String())
+	baseStep := core.NewBaseStep(core.BaseStepOptions{
+		DisplayName: displayName,
+		Env:         &util.Environment{},
+		ID:          name,
+		Name:        name,
+		Owner:       "wercker",
+		SafeID:      stepSafeID,
+		Version:     util.Version(),
+	})
+	return &DockerKillStep{
+		BaseStep:      baseStep,
+		data:          stepConfig.Data,
+		logger:        util.RootLogger().WithField("Logger", "DockerKillStep"),
+		options:       options,
+		dockerOptions: dockerOptions,
+		containerName: stepConfig.Name,
+	}, nil
+}
+
+// InitEnv parses our data into our config
+func (s *DockerKillStep) InitEnv(env *util.Environment) error {
+	return nil
+}
+
+// Fetch NOP
+func (s *DockerKillStep) Fetch() (string, error) {
+	// nop
+	return "", nil
+}
+
+// Execute kills container
+func (s *DockerKillStep) Execute(ctx context.Context, sess *core.Session) (int, error) {
+	// TODO(termie): could probably re-use the tansport's client
+	client, err := NewDockerClient(s.dockerOptions)
+	if err != nil {
+		return 1, err
+	}
+	containerToKill := s.options.RunID + s.containerName
+	killOpts := docker.KillContainerOptions{
+		ID: containerToKill,
+	}
+	s.logger.Debugln("Kill container:", containerToKill)
+	err = client.KillContainer(killOpts)
+	if err != nil {
+		s.logger.Errorln("Failed to kill container", err)
+		return -1, err
+	}
+	removeContainerOpts := docker.RemoveContainerOptions{
+		ID: containerToKill,
+	}
+	s.logger.Debugln("Remove container:", containerToKill)
+	err = client.RemoveContainer(removeContainerOpts)
+	if err != nil {
+		s.logger.Errorln("Failed to remove container", err)
+		return -1, err
+	}
+	s.logger.WithField("containerName", s.containerName).Debug("Docker-kill completed")
+	return 0, nil
+}
+
+// CollectFile NOP
+func (s *DockerKillStep) CollectFile(a, b, c string, dst io.Writer) error {
+	return nil
+}
+
+// CollectArtifact NOP
+func (s *DockerKillStep) CollectArtifact(context.Context, string) (*core.Artifact, error) {
+	return nil, nil
+}
+
+// ReportPath NOP
+func (s *DockerKillStep) ReportPath(...string) string {
+	// for now we just want something that doesn't exist
+	return uuid.NewRandom().String()
+}
+
+// ShouldSyncEnv before running this step = FALSE
+func (s *DockerKillStep) ShouldSyncEnv() bool {
+	return false
+}

--- a/docker/docker_network.go
+++ b/docker/docker_network.go
@@ -1,0 +1,190 @@
+//   Copyright © 2018, Oracle and/or its affiliates.  All rights reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package dockerlocal
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	shortid "github.com/SKAhack/go-shortid"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/wercker/wercker/util"
+)
+
+// GetDockerNetworkName returns docker network name of docker network.
+// If docker network does not exist it creates one and return its name.
+func (b *DockerBox) GetDockerNetworkName() (string, error) {
+	dockerNetworkName := b.dockerOptions.NetworkName
+	if dockerNetworkName == "" {
+		if b.options.DockerNetworkName == "" {
+			preparedDockerNetworkName, err := b.prepareDockerNetworkName()
+			if err != nil {
+				return "", err
+			}
+
+			b.options.DockerNetworkName = preparedDockerNetworkName
+			_, err = b.createDockerNetwork(b.options.DockerNetworkName)
+			if err != nil {
+				b.logger.Errorln("Error while creating network", err)
+				return "", err
+			}
+		}
+		return b.options.DockerNetworkName, nil
+	}
+	client := b.client
+	_, err := client.NetworkInfo(dockerNetworkName)
+	if err != nil {
+		b.logger.Errorln("Network does not exist", err)
+		return "", err
+	}
+	return dockerNetworkName, nil
+}
+
+// CleanDockerNetwork remove docker network if created for this pipeline.
+func (b *DockerBox) CleanDockerNetwork() error {
+	dockerNetworkName := b.dockerOptions.NetworkName
+	client := b.client
+	if dockerNetworkName == "" {
+		dockerNetworkName = b.options.DockerNetworkName
+		if dockerNetworkName != "" {
+			dockerNetwork, err := client.NetworkInfo(dockerNetworkName)
+			if err != nil {
+				b.logger.Errorln("Unable to get network Info", err)
+				return err
+			}
+			for k := range dockerNetwork.Containers {
+				err = client.DisconnectNetwork(dockerNetwork.ID, docker.NetworkConnectionOptions{
+					Container: k,
+					Force:     true,
+				})
+				if err != nil {
+					b.logger.Errorln("Error while disconnecting container from network", err)
+					return err
+				}
+			}
+			b.logger.WithFields(util.LogFields{
+				"Name": dockerNetworkName,
+			}).Debugln("Removing docker network ", dockerNetworkName)
+			err = client.RemoveNetwork(dockerNetworkName)
+			if err != nil {
+				b.logger.Errorln("Error while removing docker network", err)
+				return err
+			}
+		} else {
+			b.logger.Debugln("Network does not exist")
+		}
+	} else {
+		b.logger.Debugln("Custom netork")
+	}
+	return nil
+}
+
+// Create docker network
+func (b *DockerBox) createDockerNetwork(dockerNetworkName string) (*docker.Network, error) {
+	b.logger.Debugln("Creating docker network")
+	client := b.client
+	networkOptions := map[string]interface{}{
+		"com.docker.network.bridge.enable_ip_masquerade": "true",
+	}
+	b.logger.WithFields(util.LogFields{
+		"Name": dockerNetworkName,
+	}).Debugln("Creating docker network :", dockerNetworkName)
+	return client.CreateNetwork(docker.CreateNetworkOptions{
+		Name:           dockerNetworkName,
+		CheckDuplicate: true,
+		Options:        networkOptions,
+	})
+}
+
+// Prepares and return DockerEnvironment variables list.
+// For each service In case of docker links, docker creates some environment variables and inject them to box container.
+// Since docker links is replaced by docker network, these environment variables needs to be created manually.
+// Below environment variables created and injected to box container.
+// 01) <container name>_PORT_<port>_<protocol>_ADDR  - variable contains the IP Address.
+// 02) <container name>_PORT_<port>_<protocol>_PORT - variable contains just the port number.
+// 03) <container name>_PORT_<port>_<protocol>_PROTO - variable contains just the protocol.
+// 04) <container name>_ENV_<name> - Docker also exposes each Docker originated environment variable from the source container as an environment variable in the target.
+// 05) <container name>_PORT - variable contains the URL of the source container’s first exposed port. The ‘first’ port is defined as the exposed port with the lowest number.
+// 06) <container name>_NAME - variable is set for each service specified in wercker.yml.
+func (b *DockerBox) prepareSvcDockerEnvVar(env *util.Environment) ([]string, error) {
+	serviceEnv := []string{}
+	client := b.client
+	for _, service := range b.services {
+		serviceName := strings.Replace(service.GetServiceAlias(), "-", "_", -1)
+		if containerID := service.GetID(); containerID != "" {
+			container, err := client.InspectContainer(containerID)
+			if err != nil {
+				b.logger.Error("Error while inspecting container", err)
+				return nil, err
+			}
+			ns := container.NetworkSettings
+			var serviceIPAddress string
+			for _, v := range ns.Networks {
+				serviceIPAddress = v.IPAddress
+				break
+			}
+			serviceEnv = append(serviceEnv, fmt.Sprintf("%s_NAME=/%s/%s", strings.ToUpper(serviceName), b.getContainerName(), serviceName))
+			lowestPort := math.MaxInt32
+			var protLowestPort string
+			for k := range container.Config.ExposedPorts {
+				exposedPort := strings.Split(string(k), "/") //exposedPort[0]=portNum and exposedPort[1]=protocal(tcp/udp)
+				x, err := strconv.Atoi(exposedPort[0])
+				if err != nil {
+					b.logger.Error("Unable to convert string port to integer", err)
+					return nil, err
+				}
+				if lowestPort > x {
+					lowestPort = x
+					protLowestPort = exposedPort[1]
+				}
+				dockerEnvPrefix := fmt.Sprintf("%s_PORT_%s_%s", strings.ToUpper(serviceName), exposedPort[0], strings.ToUpper(exposedPort[1]))
+				serviceEnv = append(serviceEnv, fmt.Sprintf("%s=%s://%s:%s", dockerEnvPrefix, exposedPort[1], serviceIPAddress, exposedPort[0]))
+				serviceEnv = append(serviceEnv, fmt.Sprintf("%s_ADDR=%s", dockerEnvPrefix, serviceIPAddress))
+				serviceEnv = append(serviceEnv, fmt.Sprintf("%s_PORT=%s", dockerEnvPrefix, exposedPort[0]))
+				serviceEnv = append(serviceEnv, fmt.Sprintf("%s_PROTO=%s", dockerEnvPrefix, exposedPort[1]))
+			}
+			if protLowestPort != "" {
+				serviceEnv = append(serviceEnv, fmt.Sprintf("%s_PORT=%s://%s:%s", strings.ToUpper(serviceName), protLowestPort, serviceIPAddress, strconv.Itoa(lowestPort)))
+			}
+			for _, envVar := range container.Config.Env {
+				serviceEnv = append(serviceEnv, fmt.Sprintf("%s_ENV_%s", strings.ToUpper(serviceName), envVar))
+			}
+		}
+	}
+	b.logger.Debug("Exposed Service Evnironment variables", serviceEnv)
+	return serviceEnv, nil
+}
+
+// Generate docker network name and check if same is already in use. In case name is already in use then it regenerate it upto 3 times before throwing error.
+func (b *DockerBox) prepareDockerNetworkName() (string, error) {
+	generator := shortid.Generator()
+	client := b.client
+
+	for i := 0; i < 3; i++ {
+		dockerNetworkName := generator.Generate()
+		dockerNetworkName = "w-" + dockerNetworkName
+		network, _ := client.NetworkInfo(dockerNetworkName)
+		if network != nil {
+			b.logger.Debugln("Network name exist, retrying...")
+		} else {
+			return dockerNetworkName, nil
+		}
+	}
+	err := fmt.Errorf("Unable to prepare unique network name")
+	b.logger.Errorln(err)
+	return "", err
+}

--- a/docker/docker_run.go
+++ b/docker/docker_run.go
@@ -1,0 +1,330 @@
+//   Copyright © 2018, Oracle and/or its affiliates.  All rights reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package dockerlocal
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fsouza/go-dockerclient"
+	"github.com/google/shlex"
+	"github.com/pborman/uuid"
+	"github.com/wercker/wercker/auth"
+	"github.com/wercker/wercker/core"
+	"github.com/wercker/wercker/util"
+	"golang.org/x/net/context"
+)
+
+type DockerRunStep struct {
+	*core.BaseStep
+	options               *core.PipelineOptions
+	dockerOptions         *Options
+	data                  map[string]string
+	env                   []string
+	logger                *util.LogEntry
+	Cmd                   []string
+	EntryPoint            []string
+	WorkingDir            string
+	PortBindings          map[docker.Port][]docker.PortBinding
+	ExposedPorts          map[docker.Port]struct{}
+	User                  string
+	ContainerName         string
+	OriginalContainerName string
+	Image                 string
+	ContainerID           string
+	Auth                  dockerauth.CheckAccessOptions `yaml:",inline"`
+}
+
+type BoxDockerRun struct {
+	*DockerBox
+}
+
+// NewDockerRunStep is a special step for doing docker runs. "image" is the required property for this step. It first checks if the input
+// "image" is build by docker-build and resided in docker-deaon. If not, then it uses the DockerBox logic to fetch the image and starts
+// a new container on that image. The new container is started on the Box network and cleaned up at the end of pipeline.
+func NewDockerRunStep(stepConfig *core.StepConfig, options *core.PipelineOptions, dockerOptions *Options) (*DockerRunStep, error) {
+	name := "docker-run"
+	displayName := "docker run"
+	if stepConfig.Name == "" {
+		err := fmt.Errorf("\"name\" is a required field")
+		return nil, err
+	}
+	originalContainerName := stepConfig.Name
+
+	// Add a random number to the name to prevent collisions on disk
+	stepSafeID := fmt.Sprintf("%s-%s", name, uuid.NewRandom().String())
+
+	baseStep := core.NewBaseStep(core.BaseStepOptions{
+		DisplayName: displayName,
+		Env:         &util.Environment{},
+		ID:          name,
+		Name:        name,
+		Owner:       "wercker",
+		SafeID:      stepSafeID,
+		Version:     util.Version(),
+	})
+
+	return &DockerRunStep{
+		BaseStep:              baseStep,
+		data:                  stepConfig.Data,
+		logger:                util.RootLogger().WithField("Logger", "DockerRunStep"),
+		options:               options,
+		dockerOptions:         dockerOptions,
+		OriginalContainerName: originalContainerName,
+	}, nil
+}
+
+// InitEnv parses our data into our config
+func (s *DockerRunStep) InitEnv(env *util.Environment) error {
+	err := s.configure(env)
+	return err
+}
+
+func (s *DockerRunStep) configure(env *util.Environment) error {
+	if s.options.ExposePorts {
+		if ports, ok := s.data["ports"]; ok {
+			parts, err := shlex.Split(ports)
+			if err != nil {
+				return err
+			}
+			s.PortBindings = portBindings(parts)
+			s.ExposedPorts = exposedPorts(parts)
+
+		}
+	}
+
+	if workingDir, ok := s.data["working-dir"]; ok {
+		s.WorkingDir = env.Interpolate(workingDir)
+	}
+
+	image, err := getCorrectImageName(env, s)
+	if err != nil {
+		return err
+	}
+	s.Image = image
+
+	s.OriginalContainerName = env.Interpolate(s.OriginalContainerName)
+	s.ContainerName = s.options.RunID + s.OriginalContainerName
+
+	if cmd, ok := s.data["cmd"]; ok {
+		parts, err := shlex.Split(cmd)
+		if err != nil {
+			return err
+		}
+		s.Cmd = parts
+	}
+
+	if entryPoint, ok := s.data["entrypoint"]; ok {
+		parts, err := shlex.Split(entryPoint)
+		if err != nil {
+			return err
+		}
+		s.EntryPoint = parts
+	}
+
+	if envi, ok := s.data["env"]; ok {
+		parsedEnv, err := shlex.Split(envi)
+
+		if err != nil {
+			return err
+		}
+		interpolatedEnv := make([]string, len(parsedEnv))
+		for i, envVar := range parsedEnv {
+			interpolatedEnv[i] = env.Interpolate(envVar)
+		}
+		s.env = interpolatedEnv
+	}
+
+	if user, ok := s.data["user"]; ok {
+		s.User = env.Interpolate(user)
+	}
+	return nil
+}
+
+// The most important point in this function is that the required image is not pulled at first but the pipeline run-id is appended to
+// the input image name and its existence is checked locally. If that fails only then the input image is pulled from its respective registry.
+// This is done like this because docker-run is usually run in integration with docker-build. And, docker-build image is present in the
+// docker-deamon by <BuildId><image> name.
+func getCorrectImageName(env *util.Environment, s *DockerRunStep) (string, error) {
+	i := env.Interpolate(s.data["image"])
+	if i == "" {
+		err := fmt.Errorf("\"image\" is a required field")
+		return "", err
+	}
+
+	client, err := NewDockerClient(s.dockerOptions)
+	if err != nil {
+		return "", err
+	}
+
+	// local image should exists with a prepend of build id.
+	image, err := client.InspectImage(s.options.RunID + i)
+	if err != nil {
+		return i, nil
+	}
+	return image.ID, nil
+
+}
+
+// NewBoxDockerRun gives a wrapper for a box.
+func NewBoxDockerRun(boxConfig *core.BoxConfig, options *core.PipelineOptions, dockerOptions *Options) (*BoxDockerRun, error) {
+	box, err := NewDockerBox(boxConfig, options, dockerOptions)
+	if err != nil {
+		return nil, err
+	}
+	return &BoxDockerRun{DockerBox: box}, err
+}
+
+// Fetch NOP
+func (s *DockerRunStep) Fetch() (string, error) {
+	return "", nil
+}
+
+// Execute creates the container and starts the container.
+func (s *DockerRunStep) Execute(ctx context.Context, sess *core.Session) (int, error) {
+	boxConfig := &core.BoxConfig{
+		ID: s.Image,
+	}
+	dockerRunDockerBox, err := NewBoxDockerRun(boxConfig, s.options, s.dockerOptions)
+	if err != nil {
+		s.logger.Errorln("Error in creating a box from boxConfig ", boxConfig)
+		return 1, err
+	}
+	networkName, err := dockerRunDockerBox.GetDockerNetworkName()
+	if err != nil {
+		return 1, err
+	}
+
+	dockerRunDockerBox.Fetch(ctx, s.Env())
+
+	client, err := NewDockerClient(s.dockerOptions)
+	if err != nil {
+		return 1, err
+	}
+
+	conf := &docker.Config{
+		Image:        s.Image,
+		Cmd:          s.Cmd,
+		Env:          s.env,
+		ExposedPorts: s.ExposedPorts,
+		Entrypoint:   s.EntryPoint,
+		DNS:          s.dockerOptions.DNS,
+		WorkingDir:   s.WorkingDir,
+	}
+
+	hostconfig := &docker.HostConfig{
+		DNS:          s.dockerOptions.DNS,
+		PortBindings: s.PortBindings,
+		NetworkMode:  networkName,
+	}
+
+	endpointConfig := &docker.EndpointConfig{
+		Aliases: []string{s.OriginalContainerName},
+	}
+	endpointConfigMap := make(map[string]*docker.EndpointConfig)
+	endpointConfigMap[networkName] = endpointConfig
+
+	networkingconfig := &docker.NetworkingConfig{
+		EndpointsConfig: endpointConfigMap,
+	}
+
+	container, err := s.createContainer(client, conf, hostconfig, networkingconfig)
+	if err != nil {
+		s.logger.Errorln("Error in creating container name : ", s.ContainerName)
+		return 1, err
+	}
+	s.logger.Infoln("Container is created with container id : ", container.ID)
+
+	s.ContainerID = container.ID
+
+	err = s.startContainer(client, hostconfig)
+	if err != nil {
+		s.logger.Errorln("Error in starting container name : ", s.ContainerName)
+		return 1, err
+	}
+	s.logger.Infoln("Container is successfully started name : ", s.ContainerName)
+
+	return 0, nil
+}
+
+func (s *DockerRunStep) createContainer(client *DockerClient, conf *docker.Config, hostconfig *docker.HostConfig, networkingConfig *docker.NetworkingConfig) (*docker.Container, error) {
+	container, err := client.CreateContainer(
+		docker.CreateContainerOptions{
+			Name:             s.ContainerName,
+			Config:           conf,
+			HostConfig:       hostconfig,
+			NetworkingConfig: networkingConfig,
+		})
+	return container, err
+}
+
+func (s *DockerRunStep) startContainer(client *DockerClient, hostConfig *docker.HostConfig) error {
+	err := client.StartContainer(s.ContainerName, hostConfig)
+	return err
+}
+
+// CollectFile NOP
+func (s *DockerRunStep) CollectFile(a, b, c string, dst io.Writer) error {
+	return nil
+}
+
+// CollectArtifact NOP
+func (s *DockerRunStep) CollectArtifact(context.Context, string) (*core.Artifact, error) {
+	return nil, nil
+}
+
+// ReportPath NOP
+func (s *DockerRunStep) ReportPath(...string) string {
+	// for now we just want something that doesn't exist
+	return uuid.NewRandom().String()
+}
+
+// ShouldSyncEnv before running this step = TRUE
+func (s *DockerRunStep) ShouldSyncEnv() bool {
+	// If disable-sync is set, only sync if it is not true
+	if disableSync, ok := s.data["disable-sync"]; ok {
+		return disableSync != "true"
+	}
+	return true
+}
+
+func (s *DockerRunStep) Clean() {
+	client, err := NewDockerClient(s.dockerOptions)
+	if err != nil {
+		s.logger.Errorln("Error in creating docker client")
+		return
+	}
+
+	container, _ := client.InspectContainer(s.ContainerID)
+	if container != nil {
+
+		err = client.StopContainer(s.ContainerID, 1)
+		if err != nil {
+			s.logger.Errorln("Error in stopping the container with id : ", s.ContainerID)
+		}
+
+		opts := docker.RemoveContainerOptions{
+			ID:            s.ContainerID,
+			RemoveVolumes: true,
+			Force:         true,
+		}
+		err = client.RemoveContainer(opts)
+		if err != nil {
+			s.logger.Errorln("Error in deleting the container with id : ", s.ContainerID)
+		}
+	} else {
+		s.logger.Debugln(fmt.Sprintf("Container %s, already removed", s.ContainerID))
+	}
+}

--- a/docker/options.go
+++ b/docker/options.go
@@ -38,6 +38,7 @@ type Options struct {
 	MemorySwap        int64
 	KernelMemory      int64
 	CleanupImage      bool
+	NetworkName       string
 }
 
 func guessAndUpdateDockerOptions(ctx context.Context, opts *Options, e *util.Environment) {
@@ -122,6 +123,7 @@ func NewOptions(ctx context.Context, c util.Settings, e *util.Environment) (*Opt
 	dockerMemorySwap, _ := c.Int("docker-memory-swap")
 	dockerKernelMemory, _ := c.Int("docker-kernel-memory")
 	dockerCleanupImage, _ := c.Bool("docker-cleanup-image")
+	dockerNetworkName, _ := c.String("docker-network")
 
 	speculativeOptions := &Options{
 		Host:              dockerHost,
@@ -136,6 +138,7 @@ func NewOptions(ctx context.Context, c util.Settings, e *util.Environment) (*Opt
 		MemorySwap:        int64(dockerMemorySwap) * 1024 * 1024,
 		KernelMemory:      int64(dockerKernelMemory) * 1024 * 1024,
 		CleanupImage:      dockerCleanupImage,
+		NetworkName:       dockerNetworkName,
 	}
 
 	// We're going to try out a few settings and set DockerHost if

--- a/docker/service.go
+++ b/docker/service.go
@@ -1,4 +1,4 @@
-//   Copyright 2016 Wercker Holding BV
+//   Copyright © 2016, 2018, Oracle and/or its affiliates.  All rights reserved.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ func (b *InternalServiceBox) getContainerName() string {
 }
 
 // Run executes the service
-func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment, links []string) (*docker.Container, error) {
+func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment) (*docker.Container, error) {
 	e, err := core.EmitterFromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -174,10 +174,15 @@ func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment, lin
 		portsToBind = b.config.Ports
 	}
 
+	networkName, err := b.GetDockerNetworkName()
+	if err != nil {
+		return nil, err
+	}
+
 	hostConfig := &docker.HostConfig{
 		DNS:          b.dockerOptions.DNS,
 		PortBindings: portBindings(portsToBind),
-		Links:        links,
+		NetworkMode:  networkName,
 	}
 
 	if len(binds) > 0 {
@@ -210,11 +215,20 @@ func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment, lin
 		conf.MemorySwap = swap
 	}
 
+	endpointConfig := &docker.EndpointConfig{
+		Aliases: []string{b.GetServiceAlias()},
+	}
+	endpointConfigMap := make(map[string]*docker.EndpointConfig)
+	endpointConfigMap[networkName] = endpointConfig
+
 	container, err := client.CreateContainer(
 		docker.CreateContainerOptions{
 			Name:       b.getContainerName(),
 			Config:     conf,
 			HostConfig: hostConfig,
+			NetworkingConfig: &docker.NetworkingConfig{
+				EndpointsConfig: endpointConfigMap,
+			},
 		})
 
 	if err != nil {
@@ -270,6 +284,14 @@ func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment, lin
 			})
 		}
 	}()
-
 	return container, nil
+}
+
+// GetServiceAlias returns service alias for the service.
+func (b *InternalServiceBox) GetServiceAlias() string {
+	name := b.config.Name
+	if name == "" {
+		name = b.ShortName
+	}
+	return name
 }

--- a/docker/service.go
+++ b/docker/service.go
@@ -106,7 +106,7 @@ func (b *InternalServiceBox) getContainerName() string {
 }
 
 // Run executes the service
-func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment) (*docker.Container, error) {
+func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment, envVars []string) (*docker.Container, error) {
 	e, err := core.EmitterFromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -120,6 +120,7 @@ func (b *InternalServiceBox) Run(ctx context.Context, env *util.Environment) (*d
 
 	// Import the environment and command
 	myEnv := dockerEnv(b.config.Env, env)
+	myEnv = append(myEnv, envVars...)
 
 	origEntrypoint := b.image.Config.Entrypoint
 	origCmd := b.image.Config.Cmd

--- a/docker/step.go
+++ b/docker/step.go
@@ -42,6 +42,13 @@ func NewStep(config *core.StepConfig, options *core.PipelineOptions, dockerOptio
 	if config.ID == "internal/publish-step" {
 		return NewPublishStep(config, options, dockerOptions)
 	}
+	if config.ID == "internal/docker-run" {
+		return NewDockerRunStep(config, options, dockerOptions)
+	}
+	if config.ID == "internal/docker-kill" {
+		return NewDockerKillStep(config, options, dockerOptions)
+	}
+
 	if strings.HasPrefix(config.ID, "internal/") {
 		if !options.EnableDevSteps {
 			util.RootLogger().Warnln("Ignoring dev step:", config.ID)

--- a/test-all.sh
+++ b/test-all.sh
@@ -42,6 +42,8 @@ pullImages () {
   pullIfNeeded "ubuntu"
   pullIfNeeded "golang"
   pullIfNeeded "postgres:9.6"
+  pullIfNeeded "elasticsearch"
+  pullIfNeeded "interactivesolutions/eatmydata-mysql-server"
 }
 
 basicTest() {
@@ -117,8 +119,11 @@ runTests() {
   source $testsDir/docker-push/test.sh || return 1
   source $testsDir/docker-build/test.sh || return 1
   source $testsDir/docker-push-image/test.sh || return 1
+  source $testsDir/docker-networks/test.sh || return 1
+  source $testsDir/docker-kill/test.sh || return 1
 
   export X_TEST_SERVICE_VOL_PATH=$testsDir/test-service-vol
+  basicTest "docker run" build "$testsDir/docker-run" --docker-local || return 1
   basicTest "service volume"    build "$testsDir/service-volume" --docker-local --enable-volumes  || return 1
   grep -q "test-volume-file" "${workingDir}/service volume.log" || return 1
   basicTest "source-path"       build "$testsDir/source-path" --docker-local || return 1

--- a/tests/projects/docker-kill/test.sh
+++ b/tests/projects/docker-kill/test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This is intended to be called from wercker/test-all.sh, which sets the required environment variables
+# if you run this file directly, you need to set $wercker, $workingDir and $testDir
+# as a convenience, if these are not set then assume we're running from the local directory 
+if [ -z ${wercker} ]; then wercker=$PWD/../../../wercker; fi
+if [ -z ${workingDir} ]; then workingDir=$PWD/../../../.werckertests; mkdir -p "$workingDir"; fi
+if [ -z ${testsDir} ]; then testsDir=$PWD/..; fi
+
+testDockerKill () {
+  echo -n "testing docker-kill.."
+  testDir=$testsDir/docker-kill
+  logFile="${workingDir}/docker-kill.log"
+  $wercker build "$testDir" --docker-local --working-dir "$workingDir" &> "$logFile"
+  if [ $? -eq 0 ]; then
+    cName=`docker ps -a | grep myTestContainer | awk '{print $NF}'`
+    if [ ! "$cName" ]; then
+      echo "passed"
+      return 0
+    else
+      echo 'failed'
+      cat "$logFile"
+      docker images
+      return 1
+    fi
+  else
+    echo 'failed'
+    cat "$logFile"
+    docker images
+    return 1
+  fi
+}
+
+testDockerKillAll() {
+  testDockerKill || return 1 
+}
+
+testDockerKillAll

--- a/tests/projects/docker-kill/wercker.yml
+++ b/tests/projects/docker-kill/wercker.yml
@@ -1,0 +1,9 @@
+build:
+  box: golang
+  steps:
+    - internal/docker-run:
+        image: elasticsearch
+        name: myTestContainer 
+    - internal/docker-kill:
+        name: myTestContainer
+

--- a/tests/projects/docker-networks/test.sh
+++ b/tests/projects/docker-networks/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# This is intended to be called from wercker/test-all.sh, which sets the required environment variables
+# if you run this file directly, you need to set $wercker, $workingDir and $testDir
+# as a convenience, if these are not set then assume we're running from the local directory 
+if [ -z ${wercker} ]; then wercker=$PWD/../../../wercker; fi
+if [ -z ${workingDir} ]; then workingDir=$PWD/../../../.werckertests; mkdir -p "$workingDir"; fi
+if [ -z ${testsDir} ]; then testsDir=$PWD/..; fi
+
+testDockerNetworks () {
+  echo -n "testing docker-networks.."
+  testName=docker-networks
+  testDir=$testsDir/docker-networks
+  logFile="${workingDir}/docker-n-networks.log"
+
+  $wercker build "$testDir" --docker-local --working-dir "$workingDir" &> "${workingDir}/${testName}.log"
+  if [ $? -eq 0 ]; then
+    echo "passed"
+    return 0
+  else
+      echo 'failed'
+      cat "$logFile"
+      docker images
+      return 1
+  fi
+}
+
+testDockerNetworksAll() {
+  testDockerNetworks || return 1 
+}
+
+testDockerNetworksAll

--- a/tests/projects/docker-networks/wercker.yml
+++ b/tests/projects/docker-networks/wercker.yml
@@ -1,0 +1,102 @@
+box: golang 
+services:
+- name: postgres-1
+  id: postgres
+  tag: 9.6
+  env:
+    POSTGRES_PASSWORD: test
+    POSTGRES_USER: test
+- name: mysql
+  id:  interactivesolutions/eatmydata-mysql-server
+  cmd: mysqld --innodb_flush_log_at_trx_commit=2 --innodb_log_buffer_size=3M --innodb_buffer_pool_size=180M --log-output=NONE --slow-query-log=0
+  env:
+    MYSQL_ROOT_PASSWORD: rootpasswd
+    MYSQL_USER: testuser
+    MYSQL_PASSWORD: testpasswd
+    MYSQL_DATABASE: testdb
+
+build:
+  steps:
+    - script:
+       name: go build
+       code: |
+
+         ping -c 2 postgres-1
+
+         if [ -z "$POSTGRES_1_PORT_5432_TCP_ADDR" ] 
+         then
+           exit 2
+         fi
+         
+         if [ -z "$POSTGRES_1_PORT_5432_TCP_PORT" ] || [ "$POSTGRES_1_PORT_5432_TCP_PORT" != "5432" ] 
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_1_PORT_5432_TCP_PROTO" ] || [ "$POSTGRES_1_PORT_5432_TCP_PROTO" != "tcp" ] 
+         then
+           exit 2
+         fi
+         
+         if [ -z "$POSTGRES_1_PORT_5432_TCP" ] || [ "$POSTGRES_1_PORT_5432_TCP" != "$POSTGRES_1_PORT_5432_TCP_PROTO://$POSTGRES_1_PORT_5432_TCP_ADDR:$POSTGRES_1_PORT_5432_TCP_PORT" ] 
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_1_PORT" ] || [ "$POSTGRES_1_PORT" != "$POSTGRES_1_PORT_5432_TCP_PROTO://$POSTGRES_1_PORT_5432_TCP_ADDR:$POSTGRES_1_PORT_5432_TCP_PORT" ] 
+         then
+           exit 2
+         fi
+         
+         if [ -z "$POSTGRES_1_NAME" ] 
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_1_ENV_PGDATA" ] 
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_1_ENV_PATH" ] 
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_1_ENV_LANG" ] 
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_1_ENV_PG_VERSION" ] 
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_1_ENV_GOSU_VERSION" ] 
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_1_ENV_PG_MAJOR" ] || [ "$POSTGRES_1_ENV_PG_MAJOR" != "9.6" ] 
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_1_ENV_POSTGRES_USER" ] || [ "$POSTGRES_1_ENV_POSTGRES_USER" != "test" ] 
+         then
+           exit 2
+         fi
+
+         if [ -z "$POSTGRES_1_ENV_POSTGRES_PASSWORD" ] || [ "$POSTGRES_1_ENV_POSTGRES_PASSWORD" != "test" ]
+         then
+           exit 2
+         fi
+         
+    - script:
+      code: | 
+        apt-get update
+        apt-get -y install mysql-client
+        while ! mysqladmin ping -h"mysql" --user="$MYSQL_ENV_MYSQL_USER" --password="$MYSQL_ENV_MYSQL_PASSWORD"; do
+            sleep 1
+        done

--- a/tests/projects/docker-run/Dockerfile
+++ b/tests/projects/docker-run/Dockerfile
@@ -1,0 +1,14 @@
+# Step #1 Run unit tests and build an executable that doesn't require the go libs
+FROM golang as firststage
+WORKDIR /work
+ADD . .
+RUN go test ./...
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o myapp .
+#
+# Step #2: Copy the executable into a minimal image (less than 5MB) 
+#         which doesn't contain the build tools and artifacts
+FROM alpine:latest  
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=firststage /work/myapp .
+CMD ["./myapp"]  

--- a/tests/projects/docker-run/main.go
+++ b/tests/projects/docker-run/main.go
@@ -1,0 +1,44 @@
+//   Copyright © 2018, Oracle and/or its affiliates.  All rights reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+)
+
+// envHandler handles queries of the form /env/foo
+// foo is the name of an environment variable
+// and this handler returns its value
+func envHandler(res http.ResponseWriter, req *http.Request) {
+	varname := req.URL.Path[len("/env/"):]
+	value := os.Getenv(varname)
+	res.Header().Set("Content-Type", "application/json; charset=utf-8")
+	res.Write([]byte(value))
+}
+
+func defaultHandler(res http.ResponseWriter, req *http.Request) {
+	res.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	res.Write([]byte("Hello World!"))
+}
+
+func main() {
+	http.HandleFunc("/", defaultHandler)
+	http.HandleFunc("/env/", envHandler)
+	err := http.ListenAndServe(":5001", nil)
+	if err != nil {
+		log.Fatal("Unable to listen on port 5001 : ", err)
+	}
+}

--- a/tests/projects/docker-run/wercker.yml
+++ b/tests/projects/docker-run/wercker.yml
@@ -1,0 +1,22 @@
+build:
+  box: golang
+  steps:
+    - internal/docker-build:
+        image-name: docker-push-image-name-1
+    - internal/docker-run:
+        image: docker-push-image-name-1
+        name: myTestContainer
+    - script:
+        name: Test Container 
+        code: |
+            if curlOutput=`curl -s myTestContainer:5001`; then
+                if [ "$curlOutput" == "Hello World!" ]; then
+                    echo "Test passed: container gave expected response"
+                else
+                    echo "Test failed: container gave unexpected response: " $curlOutput
+                    exit 1
+                fi
+            else
+                echo "Test failed: container did not respond"
+                exit 1
+            fi

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -121,6 +121,12 @@
 			"revisionTime": "2012-06-04T00:48:16Z"
 		},
 		{
+			"checksumSHA1": "jtbaBG/rd1lbQ9N0KfzC7IiIIMI=",
+			"path": "github.com/SKAhack/go-shortid",
+			"revision": "24d054c393feb4d0a6514de8a9951a26fedf0d85",
+			"revisionTime": "2014-08-27T05:08:53Z"
+		},
+		{
 			"checksumSHA1": "7oJ+tBkFGffV4LP/fDBbFb/XTVw=",
 			"path": "github.com/aws/aws-sdk-go/aws",
 			"revision": "96feaee0a1328835f6336932f48ba7c90df90244",


### PR DESCRIPTION

- Changes from last Review 
   01) Instead of using default values for below parameter, values are specified directly. Its a good practice to specify values as change in docker version might change defaults.
		"com.docker.network.bridge.enable_icc":           "true",
		"com.docker.network.driver.mtu":                       "1500",
   02) Environment variables are pushed to services as well. 

- Canary testing on production after customer approval.
   https://app.wercker.com/Trizic/platform/runs/build/5afe68237c06ca0001ec92aa?step=5afe68b66968e60001343fd5

- previous reviews.
    https://github.com/wercker/wercker/pull/405/files
    https://github.com/wercker/wercker/pull/407/files
   