### PR TITLE
Allow switching between external runners on dev.wercker.com and app.wercker.com

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -55,7 +55,7 @@ var (
 	// These flags control where we store local files
 	LocalPathFlags = []cli.Flag{
 		cli.StringFlag{Name: "working-dir", Value: "./.wercker", Usage: "Path where we store working files.", EnvVar: "WERCKER_WORKING_DIR"},
-		cli.StringFlag{Name: "local-file-store", Usage: "Path where external runner stores pipeline files"},
+		cli.StringFlag{Name: "local-file-store", Usage: "Path where external runner stores pipeline files", Hidden: true},
 	}
 
 	// These flags control paths on the guest and probably shouldn't change
@@ -252,6 +252,16 @@ var (
 	WerckerDockerFlagSet = [][]cli.Flag{
 		AuthFlags,
 		WerckerFlags,
+	}
+
+	ExternalRunnerCommonFlagSet = [][]cli.Flag{
+		ExternalRunnerCommonFlags,
+	}
+	ExternalRunnerConfigureFlagSet = [][]cli.Flag{
+		ExternalRunnerConfigureFlags,
+	}
+	ExternalRunnerStartFlagSet = [][]cli.Flag{
+		ExternalRunnerStartFlags,
 	}
 
 	ExternalRunnerCommonFlags = []cli.Flag{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -393,7 +393,7 @@ var (
 						params.RunDockerController(false)
 					}
 				},
-				Flags: ExternalRunnerStartFlags,
+				Flags: FlagsFor(ExternalRunnerStartFlagSet, GlobalFlagSet),
 			},
 			{
 				Name:  "stop",
@@ -464,6 +464,7 @@ func setupExternalRunnerParams(c *cli.Context, params *external.RunnerParams) er
 	params.PollFreq = opts.Polling
 	params.DockerEndpoint = opts.DockerEndpoint
 	params.Logger = cliLogger
+	params.ProdType = opts.Production
 
 	return nil
 }

--- a/core/options.go
+++ b/core/options.go
@@ -957,6 +957,7 @@ type WerckerRunnerOptions struct {
 	AllOption      bool
 	NoWait         bool
 	PullRemote     bool
+	Production     bool
 }
 
 // NewExternalRunnerOptions -
@@ -979,6 +980,12 @@ func NewExternalRunnerOptions(c util.Settings, e *util.Environment) (*WerckerRun
 	dhost, _ := c.String("docker-host")
 	nwait, _ := c.Bool("nowait")
 	pulls, _ := c.Bool("pull")
+
+	prod := false
+	erBaseURL, _ := c.String("base-url")
+	if erBaseURL != "" && erBaseURL == DEFAULT_BASE_URL {
+		prod = true
+	}
 
 	if dhost == "" {
 		dhost = "unix:///var/run/docker.sock"
@@ -1006,5 +1013,6 @@ func NewExternalRunnerOptions(c util.Settings, e *util.Environment) (*WerckerRun
 		NoWait:         nwait,
 		DockerEndpoint: dhost,
 		PullRemote:     pulls,
+		Production:     prod,
 	}, nil
 }


### PR DESCRIPTION
Introduced --base-url parameter to runner start command. This controls whether using app.wercler.com (the default when not specified) or dev.wercker.com. 
format: --base-url=https://app.wercker.com
Note: this code depends on the external runner kiddie-pool Docker image. 

Also added code to cleanup external runner containers when wercker is interrupted. 