### PR TITLE
Fix WRKR-355 - change .IsHidden to .Hidden in documentation.go

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+- Fix wercker --help (#426)
+
 ## v1.0.1260 (2018-06-14)
 - Changes to access RDD API Service and inject RDD in build pipelines (#421)
 

--- a/cmd/documentation.go
+++ b/cmd/documentation.go
@@ -107,7 +107,7 @@ DESCRIPTION:
    {{.Description}}{{end}}{{if .Flags}}
 
 OPTIONS:
-{{range .Flags}}{{if not .IsHidden}}   {{. | shortFlag}}{{ "\n" }}{{end}}{{end}}{{end}}
+{{range .Flags}}{{if not .Hidden}}   {{. | shortFlag}}{{ "\n" }}{{end}}{{end}}{{end}}
 `
 	cli.AppHelpTemplate = `NAME:
    {{.Name}} - {{.Usage}}
@@ -126,7 +126,7 @@ COMMANDS:
    {{range .Commands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
    {{end}}{{if .Flags}}
 GLOBAL OPTIONS:
-{{range .Flags}}{{if not .IsHidden}}   {{. | shortFlag}}{{ "\n" }}{{end}}{{end}}{{end}}
+{{range .Flags}}{{if not .Hidden}}   {{. | shortFlag}}{{ "\n" }}{{end}}{{end}}{{end}}
 `
 
 	cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {


### PR DESCRIPTION
A recent upgrade was done in wercker/wercker from github.com/wercker/codegangsta-cli to gopkg.in/urfave/cli.v1 in PR https://github.com/wercker/wercker/pull/421. The codegangsta-cli implementation had a method IsHidden() implemented in Flag interface which was no longer required in urfave/cli.v1 as a flag "Hidden" is already added- but the same change was not done to the template in documentation.go and therefore when executing wercker --help on local CLI one would get an error -

panic: template: help:18:25: executing "help" at <.IsHidden>: can't evaluate field IsHidden in type cli.Flag

goroutine 1 [running]:
github.com/wercker/wercker/cmd.setupUsageFormatter.func1(0x4db7500, 0xc4200da008, 0x4d1b311, 0x214, 0x4c54960, 0xc4202504e0)
/Users/rsinghal/go/src/github.com/wercker/wercker/cmd/documentation.go:139 +0x342
github.com/wercker/wercker/vendor/gopkg.in/urfave/cli%2ev1.ShowAppHelp(0xc4201102c0, 0xc420110201, 0x14)
/Users/rsinghal/go/src/github.com/wercker/wercker/vendor/gopkg.in/urfave/cli.v1/help.go:139 +0x189
github.com/wercker/wercker/vendor/gopkg.in/urfave/cli%2ev1.(*App).Run(0xc4202504e0, 0xc4200de000, 0x2, 0x2, 0x0, 0x0)
/Users/rsinghal/go/src/github.com/wercker/wercker/vendor/gopkg.in/urfave/cli.v1/app.go:219 +0x870
main.main()
/Users/rsinghal/go/src/github.com/wercker/wercker/main.go:25 +0x4b

Fix is to change in documentation.go to test for "flag.Hidden" instead of "flag,IsHidden"