### PR TITLE
Update changelog for release v1.0.1262

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+## v1.0.1262 (2015-06-18)
+
 - Collect report artifacts from a step even if it failed (#428)
 
 ## v1.0.1260 (2018-06-14)


### PR DESCRIPTION
This PR implements a user requested feature to collect the report artifacts from a step even if that step failed. Users are putting logs, screenshots, etc., into the report directory and want to be able to access them even (especially) if the step fails.