### PR TITLE
Fix wrkr-550 - wercker --help fails for subcommands

### DIFF
--- a/cmd/documentation.go
+++ b/cmd/documentation.go
@@ -132,7 +132,7 @@ GLOBAL OPTIONS:
 	cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
 		writer := tabwriter.NewWriter(app.Writer, 0, 8, 1, '\t', 0)
 		t := template.Must(template.New("help").Funcs(
-			template.FuncMap{"shortFlag": shortFlag},
+			template.FuncMap{"shortFlag": shortFlag, "join": strings.Join},
 		).Parse(templ))
 		err := t.Execute(w, data)
 		if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -329,9 +329,8 @@ var (
 	}
 
 	dockerCommand = cli.Command{
-		Name:            "docker",
-		Usage:           "docker <docker-command> <args>...",
-		SkipFlagParsing: true,
+		Name:  "docker",
+		Usage: "docker <docker-command> <args>...",
 		Action: func(c *cli.Context) {
 			settings := util.NewCLISettings(c)
 			env := util.NewEnvironment(os.Environ()...)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,46 @@
+//   Copyright (c) 2018, Oracle and/or its affiliates.  All rights reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/wercker/wercker/util"
+)
+
+type MainSuite struct {
+	*util.TestSuite
+}
+
+func TestMainSuite(t *testing.T) {
+	suiteTester := &MainSuite{&util.TestSuite{}}
+	suite.Run(t, suiteTester)
+}
+
+//TestGetApp_HelpCommands - tests all commands and subcommnads of wercker cli
+//for the --help option
+func (s *MainSuite) TestGetApp_HelpCommands() {
+	app := GetApp()
+	for _, cmd := range app.Commands {
+		args := []string{" ", cmd.Name, "--help"}
+		err := app.Run(args)
+		s.NoError(err, "Error executing wercker %s", cmd.Name)
+		for _, subCmd := range cmd.Subcommands {
+			args := []string{" ", cmd.Name, subCmd.Name, "--help"}
+			err := app.Run(args)
+			s.NoError(err, "Error executing wercker %s %s", cmd.Name, subCmd.Name)
+		}
+	}
+}


### PR DESCRIPTION
Fixes an issue where wercker --help will fail for commands containing further subcommands (i.e. run and step). Issue existed because in https://github.com/urfave/cli/blob/8e01ec4cd3e2d84ab2fe90d8210528ffbb06d8ff/help.go#L75 - template contains a join command but the https://golang.org/pkg/text/template/ package does not contain a default function for join. Therefore we have to explicitly pass it in a https://golang.org/pkg/text/template/#FuncMap ("join": strings.Join) in documentation.go.

Also added a test for verifying all commands and subcommands for --help option.

An option "docker" was there with SkipFlagParsing as true - earlier implementation of cli implements this flag quite differently than the current version of cli (Earlier: https://github.com/wercker/codegangsta-cli/blob/aaf4a8e6c8385a77a06a8d91d934271691945f56/command.go#L70, Now: https://github.com/urfave/cli/blob/8e01ec4cd3e2d84ab2fe90d8210528ffbb06d8ff/command.go#L180) and therefore even for "wercker docker --help" - it was trying to look at presence of --auth-token. All of our other options do not skip flag parsing and neither should this one  - have removed that as otherwise tests were failing