### PR TITLE
No hidden var interpolation

### DIFF
--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -244,7 +244,7 @@ func (p *BasePipeline) ExportEnvironment(sessionCtx context.Context, sess *Sessi
 	// Export the hidden variables separately
 	sess.HideLogs()
 	defer sess.ShowLogs()
-	exit, _, err = sess.SendChecked(sessionCtx, p.Env().Hidden.Export()...)
+	exit, _, err = sess.SendChecked(sessionCtx, p.Env().Hidden.ExportHidden()...)
 	if err != nil {
 		return err
 	}

--- a/docker/box.go
+++ b/docker/box.go
@@ -389,7 +389,7 @@ func (b *DockerBox) RecoverInteractive(cwd string, pipeline core.Pipeline, step 
 
 	env := []string{}
 	env = append(env, pipeline.Env().Export()...)
-	env = append(env, pipeline.Env().Hidden.Export()...)
+	env = append(env, pipeline.Env().Hidden.ExportHidden()...)
 	env = append(env, step.Env().Export()...)
 	env = append(env, fmt.Sprintf("cd %s", cwd))
 	cmd, err := shlex.Split(b.cmd)

--- a/util/environment.go
+++ b/util/environment.go
@@ -113,7 +113,7 @@ func (e *Environment) Export() []string {
 func (e *Environment) ExportHidden() []string {
 	s := []string{}
 	for _, key := range e.Order {
-		s = append(s, fmt.Sprintf(`export %s='%q'`, key, e.Map[key]))
+		s = append(s, fmt.Sprintf(`export %s='%s'`, key, e.Map[key]))
 	}
 	return s
 }

--- a/util/environment.go
+++ b/util/environment.go
@@ -84,7 +84,7 @@ func (e *Environment) PassThruProxyConfig() {
 	for _, key := range proxyEnv {
 		value, ok := e.Map[key]
 		if ok {
-		    e.AddIfMissing(fmt.Sprintf("%s%s", public, key), value)
+			e.AddIfMissing(fmt.Sprintf("%s%s", public, key), value)
 		}
 	}
 }
@@ -104,6 +104,16 @@ func (e *Environment) Export() []string {
 	s := []string{}
 	for _, key := range e.Order {
 		s = append(s, fmt.Sprintf(`export %s=%q`, key, e.Map[key]))
+	}
+	return s
+}
+
+// ExportHidden export the environment as shell commands for use with Session.Send*.
+// Hidden variables are not interpolated on shell.
+func (e *Environment) ExportHidden() []string {
+	s := []string{}
+	for _, key := range e.Order {
+		s = append(s, fmt.Sprintf(`export %s='%q'`, key, e.Map[key]))
 	}
 	return s
 }

--- a/util/environment_test.go
+++ b/util/environment_test.go
@@ -141,6 +141,12 @@ func (s *EnvironmentSuite) TestExport() {
 	s.Equal(env.Export(), expected)
 }
 
+func (s *EnvironmentSuite) TestExportHidden() {
+	env := NewEnvironment("PUBLIC=foo$12", "PRIVATE=zed#23$67^ac_M.c-k>yx")
+	expected := []string{`export PUBLIC='"foo$12"'`, `export PRIVATE='"zed#23$67^ac_M.c-k>yx"'`}
+	s.Equal(expected, env.ExportHidden())
+}
+
 func (s *EnvironmentSuite) TestLoadFile() {
 	env := NewEnvironment("PUBLIC=foo")
 	expected := [][]string{

--- a/util/environment_test.go
+++ b/util/environment_test.go
@@ -143,7 +143,7 @@ func (s *EnvironmentSuite) TestExport() {
 
 func (s *EnvironmentSuite) TestExportHidden() {
 	env := NewEnvironment("PUBLIC=foo$12", "PRIVATE=zed#23$67^ac_M.c-k>yx")
-	expected := []string{`export PUBLIC='"foo$12"'`, `export PRIVATE='"zed#23$67^ac_M.c-k>yx"'`}
+	expected := []string{`export PUBLIC='foo$12'`, `export PRIVATE='zed#23$67^ac_M.c-k>yx'`}
 	s.Equal(expected, env.ExportHidden())
 }
 


### PR DESCRIPTION
Problem :- Password field can have special char (like $), which are interpolated on shell. OCIR passwords generally has $ sign because of which docker-push step is failing.


Solution :- Generally password are protected strings. In code they are evaluated separately as Hidden environment var.
While creating export statement and making (`export %s= '%s'`, key, e.Map[key]) change, special characters(like $) in Hidden list are not evaluated. 

Impact :- Users who were using interpolation feature on shell for protected variables would be impacted. I belive few users would be using interpolation feature in protected variables, so impact will be minimal.

Testcase executed are as follows 
a) When password contains $ (ChangeMe$1) and its a protected variable defined in UI

	01) password = ChangeMe$1 . Result=Pass
		https://dev.wercker.com/gauagnih/wercker-docker-push/runs/build/5b6abf5375e29b0006483331
	
	02) password = K-_&V4f>M.j^S`kf$Qf2+It1 . Result=Pass
		https://dev.wercker.com/gauagnih/wercker-docker-push/runs/build/5b6c095f75e29b000648378d

	03) password = K-_&V4f>M.jSkf$Qf2+It1 . Result=Pass
		https://dev.wercker.com/gauagnih/wercker-docker-push/runs/build/5b6c083978f7dd00070062eb


b) When password contains $ (ChangeMe$1) and its a public variable defined in UI. Testcase would fail.
    https://dev.wercker.com/gauagnih/wercker-docker-push/runs/build/5b6abf1a75e29b0006483322