### PR TITLE
When docker:true is set, run the pipeline container in privileged mode

### DIFF
--- a/docker/box.go
+++ b/docker/box.go
@@ -485,11 +485,15 @@ func (b *DockerBox) Run(ctx context.Context, env *util.Environment, rddURI strin
 		portsToBind = b.config.Ports
 	}
 
+	// if we've specified direct docker access, run the container in privileged mode as it is safe to do so
+	privileged := rddURI != ""
+
 	hostConfig := &docker.HostConfig{
 		Binds:        binds,
 		PortBindings: portBindings(portsToBind),
 		DNS:          b.dockerOptions.DNS,
 		NetworkMode:  dockerNetworkName,
+		Privileged:   privileged,
 	}
 
 	conf := &docker.Config{

--- a/tests/projects/privileged/test.sh
+++ b/tests/projects/privileged/test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# This is intended to be called from wercker/test-all.sh, which sets the required environment variables
+# if you run this file directly, you need to set $wercker, $workingDir and $testDir
+# as a convenience, if these are not set then assume we're running from the local directory 
+if [ -z ${wercker} ]; then wercker=$PWD/../../../wercker; fi
+if [ -z ${workingDir} ]; then workingDir=$PWD/../../../.werckertests; mkdir -p "$workingDir"; fi
+if [ -z ${testsDir} ]; then testsDir=$PWD/..; fi
+
+# Test that if docker:true is not specified then the pipeline container is NOT run in privileged mode
+testPrivilegedModeDockerFalse () {
+  testName=privileged-mode-docker-false
+  testDir=$testsDir/privileged
+  printf "testing %s... " "$testName"
+  
+  logFile="${workingDir}/$testName.log"
+  $wercker build "$testDir" --pipeline privileged-mode-docker-false --working-dir "$workingDir" &> "$logFile"
+  if [ $? -ne 0 ]; then
+    printf "failed\n"
+    if [ "${workingDir}/${testName}.log" ]; then
+      cat "${workingDir}/${testName}.log"
+    fi
+    return 1
+  fi  
+  printf "passed\n"
+  return 0
+}
+
+# Test that if docker:true is not specified then the pipeline container is run in privileged mode
+testPrivilegedModeDockerTrue () {
+  testName=privileged-mode-docker-true
+  testDir=$testsDir/privileged
+  printf "testing %s... " "$testName"
+
+  logFile="${workingDir}/$testName.log"
+  $wercker build "$testDir" --pipeline privileged-mode-docker-true --working-dir "$workingDir" &> "$logFile"
+  if [ $? -ne 0 ]; then
+    printf "failed\n"
+    if [ "${workingDir}/${testName}.log" ]; then
+      cat "${workingDir}/${testName}.log"
+    fi
+    return 1
+  fi  
+  printf "passed\n"
+  return 0
+}
+
+testPrivilegedModeAll () {
+  testPrivilegedModeDockerFalse || return 1 
+  testPrivilegedModeDockerTrue || return 1 
+}
+
+testPrivilegedModeAll 

--- a/tests/projects/privileged/wercker.yml
+++ b/tests/projects/privileged/wercker.yml
@@ -1,0 +1,37 @@
+privileged-mode-docker-false:
+  box:
+    id: busybox
+    cmd: /bin/sh
+  steps:
+    - script:
+        name: test  
+        code: |
+            # verify that the pipeline container is NOT running in privileged mode
+            # https://stackoverflow.com/questions/32144575/how-to-know-if-a-docker-container-is-running-in-privileged-mode
+            set +e
+            ip link add dummy0 type dummy >/dev/null
+            if [[ $? -eq 0 ]]; then
+                echo Unexpectedly able to create link: we must be in privileged mode
+                # clean the dummy0 link
+                ip link delete dummy0 >/dev/null
+                # fail
+                exit 1
+            fi
+privileged-mode-docker-true:
+  box:
+    id: busybox
+    cmd: /bin/sh
+  docker: true
+  steps:
+    - script:
+        name: test  
+        code: |
+            # verify that the pipeline container is running in privileged mode
+            # https://stackoverflow.com/questions/32144575/how-to-know-if-a-docker-container-is-running-in-privileged-mode
+            set +e
+            ip link add dummy0 type dummy >/dev/null
+            if [[ $? -ne 0 ]]; then
+                echo Unexpectedly unable to create link: we must not be in privileged mode
+                # fail
+                exit 1
+            fi       


### PR DESCRIPTION
When the pipeline property `docker:true` is set then the pipeline container will be run on a "remote daemon" provisioned specifically for this user, which runs on a specially isolated EC2 host. Users can then start their own containers in that host. If the user desires, the user can specify that these containers are run in privileged mode.

However since the pipeline container itself is started by wercker the user can't configure it to run in privileged mode. This is inconsistent and places restrictions on what the pipeline container can do which we do not place on other containers running in the same daemon that are started by the user. This PR addresses that. 

If the pipeline property `docker:true` is set then the pipeline container will be run in privileged mode.

If the pipeline property `docker:true` is NOT set then the pipeline container is run in the restricted daemon and so privileged mode is not used. 

A new integration test verifies both cases. 