### PR TITLE
Escape special characters in bash exports

### DIFF
--- a/test-all.sh
+++ b/test-all.sh
@@ -144,11 +144,10 @@ runTests() {
   basicTest "relative symlinks" build "$testsDir/relative-symlinks" --docker-local || return 1
 
   export X_BACKSLASH='back\slash'
-  basicTest "backslash in envvar escaped" build "$testsDir/envvars" --docker-local --pipeline test-backslash || return 1
   export X_BACKTICK='back`tick'
-  basicTest "backtick in envvar escaped" build "$testsDir/envvars" --docker-local --pipeline test-backtick || return 1
   export X_BANG='ban!g'
-  basicTest "bang in envvar escaped" build "$testsDir/envvars" --docker-local --pipeline test-bang || return 1
+  export X_BANG_ESCAPED='ban\!g'
+  basicTest "special char in envvar escaped" build "$testsDir/envvars" --docker-local --pipeline test-special || return 1
 
   #return 1
 

--- a/test-all.sh
+++ b/test-all.sh
@@ -143,6 +143,13 @@ runTests() {
   basicTest "after steps"       build "$testsDir/after-steps-fail" --docker-local --pipeline build_true  || return 1
   basicTest "relative symlinks" build "$testsDir/relative-symlinks" --docker-local || return 1
 
+  export X_BACKSLASH='back\slash'
+  basicTest "backslash in envvar escaped" build "$testsDir/envvars" --docker-local --pipeline test-backslash || return 1
+  export X_BACKTICK='back`tick'
+  basicTest "backtick in envvar escaped" build "$testsDir/envvars" --docker-local --pipeline test-backtick || return 1
+  export X_BANG='ban!g'
+  basicTest "bang in envvar escaped" build "$testsDir/envvars" --docker-local --pipeline test-bang || return 1
+
   #return 1
 
   # test different shells

--- a/tests/projects/envvars/wercker.yml
+++ b/tests/projects/envvars/wercker.yml
@@ -1,27 +1,15 @@
-test-backtick:
+test-special:
   box:
     id: alpine
   steps:
     - script:
-        name: backtick escaped
+        name: backtick, bang, backslash escaped
         code: |
           [ -z "${BACKTICK}" ] && { echo "BACKTICK environment variable not set" ; exit 1 ; }
           [ "${BACKTICK}" == 'back`tick' ] || exit 1
-test-bang:
-  box:
-    id: alpine
-  steps:
-    - script:
-        name: bang escaped
-        code: |
           [ -z "${BANG}" ] && { echo "BANG environment variable not set" ; exit 1 ; }
           [ "${BANG}" == 'ban!g' ] || exit 1
-test-backslash:
-  box:
-    id: alpine
-  steps:
-    - script:
-        name: backslash escaped
-        code: |
+          [ -z "${ESCAPED_BANG}" ] && { echo "ESCAPED_BANG environment variable not set" ; exit 1 ; }
+          [ "${ESCAPED_BANG}" == 'ban!g' ] || exit 1
           [ -z "${BACKSLASH}" ] && { echo "BACKSLASH environment variable not set" ; exit 1 ; }
           [ "${BACKSLASH}" == 'back\slash' ] || exit 1

--- a/tests/projects/envvars/wercker.yml
+++ b/tests/projects/envvars/wercker.yml
@@ -1,0 +1,27 @@
+test-backtick:
+  box:
+    id: alpine
+  steps:
+    - script:
+        name: backtick escaped
+        code: |
+          [ -z "${BACKTICK}" ] && { echo "BACKTICK environment variable not set" ; exit 1 ; }
+          [ "${BACKTICK}" == 'back`tick' ] || exit 1
+test-bang:
+  box:
+    id: alpine
+  steps:
+    - script:
+        name: bang escaped
+        code: |
+          [ -z "${BANG}" ] && { echo "BANG environment variable not set" ; exit 1 ; }
+          [ "${BANG}" == 'ban!g' ] || exit 1
+test-backslash:
+  box:
+    id: alpine
+  steps:
+    - script:
+        name: backslash escaped
+        code: |
+          [ -z "${BACKSLASH}" ] && { echo "BACKSLASH environment variable not set" ; exit 1 ; }
+          [ "${BACKSLASH}" == 'back\slash' ] || exit 1

--- a/util/environment.go
+++ b/util/environment.go
@@ -103,7 +103,10 @@ func (e *Environment) Get(key string) string {
 func (e *Environment) Export() []string {
 	s := []string{}
 	for _, key := range e.Order {
-		s = append(s, fmt.Sprintf(`export %s=%q`, key, e.Map[key]))
+		export := fmt.Sprintf(`export %s=%q`, key, e.Map[key])
+		export = strings.Replace(export, "`", "\\`", -1)
+		export = strings.Replace(export, `!`, `\!`, -1)
+		s = append(s, export)
 	}
 	return s
 }

--- a/util/environment_test.go
+++ b/util/environment_test.go
@@ -138,8 +138,27 @@ func (s *EnvironmentSuite) TestOrdered() {
 func (s *EnvironmentSuite) TestExport() {
 	env := NewEnvironment("PUBLIC=foo", "X_PRIVATE=zed")
 	expected := []string{`export PUBLIC="foo"`, `export X_PRIVATE="zed"`}
-	s.Equal(env.Export(), expected)
+	s.Equal(expected, env.Export())
 }
+
+func (s *EnvironmentSuite) TestExportBacktick() {
+	env := NewEnvironment("BT1=`backtick", "BT2=back`tick", "BT3=backtick`")
+	expected := []string{`export BT1="\` + "`" + `backtick"`, `export BT2="back\` + "`" + `tick"`, `export BT3="backtick\` + "`" + `"`}
+	s.Equal(expected, env.Export())
+}
+
+func (s *EnvironmentSuite) TestExportBackslash() {
+	env := NewEnvironment(`BS1=\backslash`, `BS2=back\slash`, `BS3=backslash\`)
+	expected := []string{`export BS1="\\backslash"`, `export BS2="back\\slash"`, `export BS3="backslash\\"`}
+	s.Equal(expected, env.Export())
+}
+
+func (s *EnvironmentSuite) TestExportBang() {
+	env := NewEnvironment(`B1=!bang`, `B2=ban!g`, `B3=bang!`)
+	expected := []string{`export B1="\!bang"`, `export B2="ban\!g"`, `export B3="bang\!"`}
+	s.Equal(expected, env.Export())
+}
+
 
 func (s *EnvironmentSuite) TestLoadFile() {
 	env := NewEnvironment("PUBLIC=foo")


### PR DESCRIPTION
Including backtick causes setup environment to hang.  Also escape other characters whose special meaning is preserved in bash double quotes (with the exception of $ - treat interpolation separately).