### PR TITLE
Env var interpolation stop

### DIFF
--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -234,7 +234,10 @@ func (p *BasePipeline) SetupGuest(sessionCtx context.Context, sess *Session) err
 
 // ExportEnvironment to the session
 func (p *BasePipeline) ExportEnvironment(sessionCtx context.Context, sess *Session) error {
-	exit, _, err := sess.SendChecked(sessionCtx, p.Env().Export()...)
+	envVars := []string{}
+	envVars = append(envVars, p.Env().Export()...)
+	envVars = append(envVars, p.Env().Public.ExportNoInterpolation()...)
+	exit, _, err := sess.SendChecked(sessionCtx, envVars...)
 	if err != nil {
 		return err
 	}

--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -93,7 +93,7 @@ func (pr *PipelineResult) ExportEnvironment(sessionCtx context.Context, sess *Se
 		e.Add("WERCKER_FAILED_STEP_MESSAGE", pr.FailedStepMessage)
 	}
 
-	exit, _, err := sess.SendChecked(sessionCtx, e.Export()...)
+	exit, _, err := sess.SendChecked(sessionCtx, e.Export(false)...)
 	if err != nil {
 		return err
 	}
@@ -235,8 +235,8 @@ func (p *BasePipeline) SetupGuest(sessionCtx context.Context, sess *Session) err
 // ExportEnvironment to the session
 func (p *BasePipeline) ExportEnvironment(sessionCtx context.Context, sess *Session) error {
 	envVars := []string{}
-	envVars = append(envVars, p.Env().Export()...)
-	envVars = append(envVars, p.Env().Public.ExportNoInterpolation()...)
+	envVars = append(envVars, p.Env().Export(false)...)
+	envVars = append(envVars, p.Env().Public.Export(true)...)
 	exit, _, err := sess.SendChecked(sessionCtx, envVars...)
 	if err != nil {
 		return err
@@ -247,7 +247,7 @@ func (p *BasePipeline) ExportEnvironment(sessionCtx context.Context, sess *Sessi
 	// Export the hidden variables separately
 	sess.HideLogs()
 	defer sess.ShowLogs()
-	exit, _, err = sess.SendChecked(sessionCtx, p.Env().Hidden.Export()...)
+	exit, _, err = sess.SendChecked(sessionCtx, p.Env().Hidden.Export(true)...)
 	if err != nil {
 		return err
 	}

--- a/core/step.go
+++ b/core/step.go
@@ -455,7 +455,7 @@ func (s *ExternalStep) Execute(sessionCtx context.Context, sess *Session) (int, 
 	if err != nil {
 		return 1, err
 	}
-	_, _, err = sess.SendChecked(sessionCtx, s.env.Export()...)
+	_, _, err = sess.SendChecked(sessionCtx, s.env.Export(false)...)
 	if err != nil {
 		return 1, err
 	}

--- a/docker/box.go
+++ b/docker/box.go
@@ -390,6 +390,7 @@ func (b *DockerBox) RecoverInteractive(cwd string, pipeline core.Pipeline, step 
 	env := []string{}
 	env = append(env, pipeline.Env().Export()...)
 	env = append(env, pipeline.Env().Hidden.Export()...)
+	env = append(env, pipeline.Env().Public.ExportNoInterpolation()...)
 	env = append(env, step.Env().Export()...)
 	env = append(env, fmt.Sprintf("cd %s", cwd))
 	cmd, err := shlex.Split(b.cmd)

--- a/docker/box.go
+++ b/docker/box.go
@@ -388,10 +388,10 @@ func (b *DockerBox) RecoverInteractive(cwd string, pipeline core.Pipeline, step 
 	}
 
 	env := []string{}
-	env = append(env, pipeline.Env().Export()...)
-	env = append(env, pipeline.Env().Hidden.Export()...)
-	env = append(env, pipeline.Env().Public.ExportNoInterpolation()...)
-	env = append(env, step.Env().Export()...)
+	env = append(env, pipeline.Env().Export(false)...)
+	env = append(env, pipeline.Env().Hidden.Export(true)...)
+	env = append(env, pipeline.Env().Public.Export(true)...)
+	env = append(env, step.Env().Export(false)...)
 	env = append(env, fmt.Sprintf("cd %s", cwd))
 	cmd, err := shlex.Split(b.cmd)
 	if err != nil {

--- a/docker/build.go
+++ b/docker/build.go
@@ -64,7 +64,7 @@ func (b *DockerBuild) InitEnv(ctx context.Context, hostEnv *util.Environment) {
 	env.Update(b.CommonEnv())
 	env.Update(a)
 	env.Update(hostEnv.GetMirror())
-	env.Update(hostEnv.GetPassthru().Ordered())
+	env.Public.Update(hostEnv.GetPassthru().Ordered())
 	env.Hidden.Update(hostEnv.GetHiddenPassthru().Ordered())
 }
 

--- a/docker/deploy.go
+++ b/docker/deploy.go
@@ -70,7 +70,7 @@ func (d *DockerDeploy) InitEnv(ctx context.Context, hostEnv *util.Environment) {
 	env.Update(d.CommonEnv())
 	env.Update(a)
 	env.Update(hostEnv.GetMirror())
-	env.Update(hostEnv.GetPassthru().Ordered())
+	env.Public.Update(hostEnv.GetPassthru().Ordered())
 	env.Hidden.Update(hostEnv.GetHiddenPassthru().Ordered())
 }
 

--- a/docker/shellstep.go
+++ b/docker/shellstep.go
@@ -105,7 +105,7 @@ func (s *ShellStep) Execute(ctx context.Context, sess *core.Session) (int, error
 		return -1, err
 	}
 
-	code := s.env.Export()
+	code := s.env.Export(false)
 	code = append(code, "cd $WERCKER_SOURCE_DIR")
 	code = append(code, s.Code)
 

--- a/util/environment.go
+++ b/util/environment.go
@@ -124,6 +124,11 @@ func (e *Environment) contains(str string) bool {
 			return true
 		}
 	}
+	for _, key := range e.Public.Order {
+		if key == str {
+			return true
+		}
+	}
 	for _, key := range e.Hidden.Order {
 		if key == str {
 			return true

--- a/util/environment.go
+++ b/util/environment.go
@@ -1,4 +1,4 @@
-//   Copyright 2016 Wercker Holding BV
+// Copyright © 2016, 2018, Oracle and/or its affiliates. All rights reserved.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -205,7 +205,11 @@ func (e *Environment) GetInclHidden(key string) string {
 			return val
 		}
 	}
-
+	if e.Public != nil && e.Public.Map != nil {
+		if val, ok := e.Public.Map[key]; ok {
+			return val
+		}
+	}
 	if e.Hidden != nil && e.Hidden.Map != nil {
 		if val, ok := e.Hidden.Map[key]; ok {
 			return val

--- a/util/environment.go
+++ b/util/environment.go
@@ -30,6 +30,7 @@ var (
 // like an OrderedMap
 type Environment struct {
 	Hidden *Environment
+	Public *Environment
 	Map    map[string]string
 	Order  []string
 }
@@ -39,6 +40,7 @@ type Environment struct {
 func NewEnvironment(env ...string) *Environment {
 	e := Environment{
 		Hidden: &Environment{},
+		Public: &Environment{},
 	}
 	for _, keyvalue := range env {
 		pair := strings.SplitN(keyvalue, "=", 2)
@@ -84,7 +86,7 @@ func (e *Environment) PassThruProxyConfig() {
 	for _, key := range proxyEnv {
 		value, ok := e.Map[key]
 		if ok {
-		    e.AddIfMissing(fmt.Sprintf("%s%s", public, key), value)
+			e.AddIfMissing(fmt.Sprintf("%s%s", public, key), value)
 		}
 	}
 }
@@ -104,6 +106,15 @@ func (e *Environment) Export() []string {
 	s := []string{}
 	for _, key := range e.Order {
 		s = append(s, fmt.Sprintf(`export %s=%q`, key, e.Map[key]))
+	}
+	return s
+}
+
+// ExportNoInterpolation exports the environment as shell commands for use with Session.Send*
+func (e *Environment) ExportNoInterpolation() []string {
+	s := []string{}
+	for _, key := range e.Order {
+		s = append(s, fmt.Sprintf(`export %s='%s'`, key, e.Map[key]))
 	}
 	return s
 }

--- a/util/environment.go
+++ b/util/environment.go
@@ -102,12 +102,33 @@ func (e *Environment) Get(key string) string {
 }
 
 // Export the environment as shell commands for use with Session.Send*
-func (e *Environment) Export() []string {
+func (e *Environment) Export(noInterpolation bool) []string {
 	s := []string{}
 	for _, key := range e.Order {
-		s = append(s, fmt.Sprintf(`export %s=%q`, key, e.Map[key]))
+		if noInterpolation || e.contains(key) {
+			s = append(s, fmt.Sprintf(`export %s='%s'`, key, e.Map[key]))
+		} else {
+			s = append(s, fmt.Sprintf(`export %s=%q`, key, e.Map[key]))
+		}
 	}
 	return s
+}
+
+// contains function checks if there exist a varible in envVar list that exist in Public or Hidden list as well.
+// In case same exit it retuns true.
+// Its required while syncing environment variables.
+func (e *Environment) contains(str string) bool {
+	for _, key := range e.Public.Order {
+		if key == str {
+			return true
+		}
+	}
+	for _, key := range e.Hidden.Order {
+		if key == str {
+			return true
+		}
+	}
+	return false
 }
 
 // ExportNoInterpolation exports the environment as shell commands for use with Session.Send*

--- a/util/environment.go
+++ b/util/environment.go
@@ -86,7 +86,7 @@ func (e *Environment) PassThruProxyConfig() {
 	for _, key := range proxyEnv {
 		value, ok := e.Map[key]
 		if ok {
-		    e.AddIfMissing(fmt.Sprintf("%s%s", public, key), value)
+			e.AddIfMissing(fmt.Sprintf("%s%s", public, key), value)
 		}
 	}
 }
@@ -108,8 +108,8 @@ func (e *Environment) Export(noInterpolation bool) []string {
 		if noInterpolation || e.contains(key) {
 			s = append(s, fmt.Sprintf(`export %s='%s'`, key, e.Map[key]))
 		} else {
-				export := fmt.Sprintf(`export %s=%q`, key, e.Map[key])
-        		export = strings.Replace(export, "`", "\\`", -1)
+			export := fmt.Sprintf(`export %s=%q`, key, e.Map[key])
+			export = strings.Replace(export, "`", "\\`", -1)
 			s = append(s, fmt.Sprintf(`export %s=%q`, key, e.Map[key]))
 		}
 	}
@@ -118,7 +118,6 @@ func (e *Environment) Export(noInterpolation bool) []string {
 
 // contains function checks if there exist a varible in envVar list that exist in Public or Hidden list as well.
 // In case same exit it retuns true.
-// Its required while syncing environment variables.
 func (e *Environment) contains(str string) bool {
 	for _, key := range e.Public.Order {
 		if key == str {

--- a/util/environment.go
+++ b/util/environment.go
@@ -110,7 +110,7 @@ func (e *Environment) Export(noInterpolation bool) []string {
 		} else {
 			export := fmt.Sprintf(`export %s=%q`, key, e.Map[key])
 			export = strings.Replace(export, "`", "\\`", -1)
-			s = append(s, fmt.Sprintf(`export %s=%q`, key, e.Map[key]))
+			s = append(s, export)
 		}
 	}
 	return s

--- a/util/environment_test.go
+++ b/util/environment_test.go
@@ -1,4 +1,4 @@
-//   Copyright 2016 Wercker Holding BV
+// Copyright © 2016, 2018, Oracle and/or its affiliates. All rights reserved. */
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/util/environment_test.go
+++ b/util/environment_test.go
@@ -141,6 +141,28 @@ func (s *EnvironmentSuite) TestExport() {
 	s.Equal(env.Export(), expected)
 }
 
+func (s *EnvironmentSuite) TestExportNoInterpolation() {
+	env := NewEnvironment("PUBLIC=foo$12", "PRIVATE=zed#23$67^ac_M.c-k>yx")
+	expected := []string{`export PUBLIC='foo$12'`, `export PRIVATE='zed#23$67^ac_M.c-k>yx'`}
+	s.Equal(expected, env.ExportNoInterpolation())
+
+	env = NewEnvironment(`B1=$dollar`, `B2=dol$lar`, `B3=dollar$`)
+	expected = []string{`export B1='!bang'`, `export B2='ban!g'`, `export B3='bang!'`}
+	s.Equal(expected, env.ExportNoInterpolation())
+
+	env = NewEnvironment(`B1=!bang`, `B2=ban!g`, `B3=bang!`)
+	expected = []string{`export B1='!bang'`, `export B2='ban!g'`, `export B3='bang!'`}
+	s.Equal(expected, env.ExportNoInterpolation())
+
+	env = NewEnvironment(`BS1=\backslash`, `BS2=back\slash`, `BS3=backslash\`)
+	expected = []string{`export BS1='\backslash'`, `export BS2='back\slash'`, `export BS3='backslash\'`}
+	s.Equal(expected, env.ExportNoInterpolation())
+
+	env = NewEnvironment("BT1=`backtick", "BT2=back`tick", "BT3=backtick`")
+	expected = []string{`export BT1='` + "`" + `backtick'`, `export BT2='back` + "`" + `tick'`, `export BT3='backtick` + "`" + `'`}
+	s.Equal(expected, env.ExportNoInterpolation())
+}
+
 func (s *EnvironmentSuite) TestLoadFile() {
 	env := NewEnvironment("PUBLIC=foo")
 	expected := [][]string{

--- a/util/environment_test.go
+++ b/util/environment_test.go
@@ -138,29 +138,27 @@ func (s *EnvironmentSuite) TestOrdered() {
 func (s *EnvironmentSuite) TestExport() {
 	env := NewEnvironment("PUBLIC=foo", "X_PRIVATE=zed")
 	expected := []string{`export PUBLIC="foo"`, `export X_PRIVATE="zed"`}
-	s.Equal(env.Export(), expected)
-}
+	s.Equal(env.Export(false), expected)
 
-func (s *EnvironmentSuite) TestExportNoInterpolation() {
-	env := NewEnvironment("PUBLIC=foo$12", "PRIVATE=zed#23$67^ac_M.c-k>yx")
-	expected := []string{`export PUBLIC='foo$12'`, `export PRIVATE='zed#23$67^ac_M.c-k>yx'`}
-	s.Equal(expected, env.ExportNoInterpolation())
+	env = NewEnvironment("PUBLIC=foo$12", "PRIVATE=zed#23$67^ac_M.c-k>yx")
+	expected = []string{`export PUBLIC='foo$12'`, `export PRIVATE='zed#23$67^ac_M.c-k>yx'`}
+	s.Equal(expected, env.Export(true))
 
 	env = NewEnvironment(`B1=$dollar`, `B2=dol$lar`, `B3=dollar$`)
-	expected = []string{`export B1='!bang'`, `export B2='ban!g'`, `export B3='bang!'`}
-	s.Equal(expected, env.ExportNoInterpolation())
+	expected = []string{`export B1='$dollar'`, `export B2='dol$lar'`, `export B3='dollar$'`}
+	s.Equal(expected, env.Export(true))
 
 	env = NewEnvironment(`B1=!bang`, `B2=ban!g`, `B3=bang!`)
 	expected = []string{`export B1='!bang'`, `export B2='ban!g'`, `export B3='bang!'`}
-	s.Equal(expected, env.ExportNoInterpolation())
+	s.Equal(expected, env.Export(true))
 
 	env = NewEnvironment(`BS1=\backslash`, `BS2=back\slash`, `BS3=backslash\`)
 	expected = []string{`export BS1='\backslash'`, `export BS2='back\slash'`, `export BS3='backslash\'`}
-	s.Equal(expected, env.ExportNoInterpolation())
+	s.Equal(expected, env.Export(true))
 
 	env = NewEnvironment("BT1=`backtick", "BT2=back`tick", "BT3=backtick`")
 	expected = []string{`export BT1='` + "`" + `backtick'`, `export BT2='back` + "`" + `tick'`, `export BT3='backtick` + "`" + `'`}
-	s.Equal(expected, env.ExportNoInterpolation())
+	s.Equal(expected, env.Export(true))
 }
 
 func (s *EnvironmentSuite) TestLoadFile() {

--- a/util/environment_test.go
+++ b/util/environment_test.go
@@ -164,13 +164,13 @@ func (s *EnvironmentSuite) TestExport() {
 func (s *EnvironmentSuite) TestExportBacktick() {
 	env := NewEnvironment("BT1=`backtick", "BT2=back`tick", "BT3=backtick`")
 	expected := []string{`export BT1="\` + "`" + `backtick"`, `export BT2="back\` + "`" + `tick"`, `export BT3="backtick\` + "`" + `"`}
-	s.Equal(expected, env.Export())
+	s.Equal(expected, env.Export(false))
 }
 
 func (s *EnvironmentSuite) TestExportBackslash() {
 	env := NewEnvironment(`BS1=\backslash`, `BS2=back\slash`, `BS3=backslash\`)
 	expected := []string{`export BS1="\\backslash"`, `export BS2="back\\slash"`, `export BS3="backslash\\"`}
-	s.Equal(expected, env.Export())
+	s.Equal(expected, env.Export(false))
 }
 
 func (s *EnvironmentSuite) TestLoadFile() {


### PR DESCRIPTION
Problem :- variables defined in web are interpolated as shell variables. It creates problem if variable has special characters like $.

Solution :- Stoped interpolation of environment variables defined in web. Public variables has X_ as prefix and protected variables has XXX_ as prefix. Protected variables are already separated as Hidden env  variables. Public variables are separated as well in Public env variables.

Impact:- Pipelines using previous behaviour needs to be changed once PR is merged.   
