### PR TITLE
updated image name for docker-kill integration test

### DIFF
--- a/test-all.sh
+++ b/test-all.sh
@@ -55,7 +55,7 @@ pullImages () {
   pullIfNeeded "ubuntu"
   pullIfNeeded "golang"
   pullIfNeeded "postgres:9.6"
-  pullIfNeeded "elasticsearch"
+  pullIfNeeded "nginx"
   pullIfNeeded "interactivesolutions/eatmydata-mysql-server"
 }
 

--- a/tests/projects/docker-kill/wercker.yml
+++ b/tests/projects/docker-kill/wercker.yml
@@ -2,7 +2,7 @@ build:
   box: golang
   steps:
     - internal/docker-run:
-        image: elasticsearch
+        image: nginx
         name: myTestContainer 
     - internal/docker-kill:
         name: myTestContainer


### PR DESCRIPTION
WRKR-1183 - Integration test were failing because of unable to pull elasticsearch image. 
Not able to pull same locally as well. 
Change elasticsearch image to nginx in integration test.